### PR TITLE
Improve date readability

### DIFF
--- a/src/app/governance/components/VotingPower.tsx
+++ b/src/app/governance/components/VotingPower.tsx
@@ -1,12 +1,13 @@
 import clsx from "clsx";
 
 import { CheckIcon } from "@/app/core/components/Icons/CheckIcon";
-import { formatBalance, formatDate } from "@/app/core/util/formatter";
+import { formatBalance } from "@/app/core/util/formatter";
 import { TConnectedUserState } from "@/app/core/hooks/useConnectedUser";
-import { CycleDatesState } from "../useCycleDates";
+import { CycleDatesSuccess } from "../useCycleDates";
 import { CycleLengthSuccess } from "../useCycleLength";
 import { FistIcon } from "@/app/core/components/Icons/FistIcon";
 import { formatUnits } from "viem";
+import { differenceInDays } from "date-fns";
 
 export function VotingPower({
   minRequiredVotingPower,
@@ -23,7 +24,7 @@ export function VotingPower({
   userVotingPower: bigint | null;
   userHasVoted: boolean;
   userCanVote: boolean;
-  cycleDates: CycleDatesState;
+  cycleDates: CycleDatesSuccess;
   cycleLength: CycleLengthSuccess;
   user: TConnectedUserState;
   distributeEqually: () => void;
@@ -87,7 +88,9 @@ function NotEnoughPower() {
   );
 }
 
-function UserHasVoted({ cycleDates }: { cycleDates: CycleDatesState }) {
+function UserHasVoted({ cycleDates }: { cycleDates: CycleDatesSuccess }) {
+  const days = differenceInDays(cycleDates.end, Date.now());
+
   return (
     <div className={clsx(widgetBaseClasses, "border-status-success")}>
       <div className="flex gap-4">
@@ -100,17 +103,7 @@ function UserHasVoted({ cycleDates }: { cycleDates: CycleDatesState }) {
       </div>
       <div>
         <span className="dark:text-breadgray-grey">Next round: </span>
-        {(() => {
-          switch (cycleDates.status) {
-            case "LOADING":
-              return <span>--/--/--</span>;
-            case "SUCCESS":
-              return <span>{formatDate(cycleDates.end)}</span>;
-            case "ERROR":
-            default:
-              throw new Error("Invalid status!");
-          }
-        })()}
+        <span>In {days} {days === 1 ? "day" : "days"}</span>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes: #227

# Screenshots:
<img width="1438" alt="Screenshot 2025-02-12 at 14 54 19" src="https://github.com/user-attachments/assets/cf08e3e2-f825-42fe-91f1-d70d909c9a08" />

# Note:

The type here is moved to `Success` because of the checks done in the parent component.

```tsx
function UserHasVoted({ cycleDates }: { cycleDates: CycleDatesSuccess }) {

```

The parent has these checks already which means the component will only be rendered if it's in the success state. Check lines [174](https://github.com/BreadchainCoop/crowdstaking-v2/blob/59bcc934c731a7851458a44ee82c09ce2c6e87d6/src/app/governance/GovernancePage.tsx#L174) to [202](https://github.com/BreadchainCoop/crowdstaking-v2/blob/59bcc934c731a7851458a44ee82c09ce2c6e87d6/src/app/governance/GovernancePage.tsx#L202) in the [GovernancePage.tsx](https://github.com/BreadchainCoop/crowdstaking-v2/blob/main/src/app/governance/GovernancePage.tsx)

```tsx
if (
    castVote.status === "ERROR" ||
    currentVotingDistribution.status === "ERROR" ||
    cycleDates.status === "ERROR" ||
    cycleLength.status === "ERROR"
  )
    return (
      <div className="w-full flex flex-col items-center pt-32">
        <h1>Please wait...</h1>
        <div className="mt-6 size-10 text-breadgray-grey">
          <Spinner />
        </div>
      </div>
    );

  if (
    !voteFormState ||
    castVote.status === "LOADING" ||
    currentVotingDistribution.status === "LOADING" ||
    cycleDates.status === "LOADING" ||
    cycleLength.status === "LOADING"
  )
    return (
      <div className="w-full flex justify-center pt-32">
        <div className="size-10 text-breadgray-grey">
          <Spinner />
        </div>
      </div>
    );

```