### PR TITLE
Show more information when bread is baked

### DIFF
--- a/src/app/core/components/Header/AddTokenButton.tsx
+++ b/src/app/core/components/Header/AddTokenButton.tsx
@@ -1,17 +1,16 @@
 import { BreadIcon } from "@/app/core/components/Icons/TokenIcons";
 import { useWatchAsset } from "@/app/core/hooks/useWatchAsset";
+import clsx from "clsx";
 
-export function AddTokenButton() {
+export function AddTokenButton({ className }: { className?: string }) {
   const { watchAsset } = useWatchAsset();
 
   return (
     <button
-      className="flex w-full whitespace-nowrap rounded-full
-      mt-2 px-3 py-2
-      dark:bg-breadgray-toast bg-breadgray-white border
-      border-breadgray-white dark:hover:bg-breadgray-burnt
-      dark:border-none dark:hover:border-none
-      hover:border-breadpink-pink text-base"
+      className={clsx(
+        "flex w-full whitespace-nowrap rounded-full mt-2 px-3 py-2 dark:bg-breadgray-toast bg-breadgray-white border border-breadgray-white dark:hover:bg-breadgray-burnt dark:border-none dark:hover:border-none hover:border-breadpink-pink text-base",
+        className
+      )}
       onClick={watchAsset}
     >
       <div className="flex gap-2 m-auto items-center">

--- a/src/app/core/components/Header/MenuDetails.tsx
+++ b/src/app/core/components/Header/MenuDetails.tsx
@@ -10,6 +10,7 @@ import { useTokenBalances } from "@/app/core/context/TokenBalanceContext/TokenBa
 import { BreadIcon } from "@/app/core/components/Icons/TokenIcons";
 import { formatBalance } from "@/app/core/util/formatter";
 import { HeartIcon } from "@/app/core/components/Icons/HeartIcon";
+import { renderFormattedDecimalNumber } from "@/app/core/util/render-formatted-decimal-number";
 import { formatUnits } from "viem";
 
 interface MenuDetailsProps {
@@ -21,23 +22,6 @@ export function MenuDetails({ address }: MenuDetailsProps) {
   const { BREAD } = useTokenBalances();
   const { data: apyData, error: apyError, status: apyStatus } = useVaultAPY();
   const gnosisLink = "https://gnosisscan.io/address/";
-
-  const renderFormattedDecimalNumber = (number: string) => {
-    const part1 = number.split(".")[0];
-    const part2 = number.split(".")[1];
-
-    return (
-      <div className="w-full text-end flex tracking-wider text-lg text-breadgray-grey100 dark:text-breadgray-ultra-white leading-none">
-        <div className=" flex gap-2 font-bold justify-end">
-          <span>{part1}</span>
-        </div>
-        <div>.</div>
-        <div className="text-sm font-semibold leading-[1.1] self-end">
-          {part2}
-        </div>
-      </div>
-    );
-  };
 
   return (
     <div className="flex flex-col gap-4">

--- a/src/app/core/components/Modal/ModalUI.tsx
+++ b/src/app/core/components/Modal/ModalUI.tsx
@@ -73,7 +73,7 @@ export function ModalContent({ children }: { children: ReactNode }) {
 
 export function ModalAdviceText({ children }: { children: ReactNode }) {
   return (
-    <p className="max-w-xs text-lg leading-normal text-breadgray-burnt dark:text-breadgray-light-grey text-center pt-4 pb-2">
+    <p className="max-w-xs text-lg leading-normal text-breadgray-rye dark:text-breadgray-grey text-center pt-4 pb-2">
       {children}
     </p>
   );

--- a/src/app/core/components/Modal/TransactionModal/BakeryTransactionModal.tsx
+++ b/src/app/core/components/Modal/TransactionModal/BakeryTransactionModal.tsx
@@ -19,10 +19,15 @@ import { BakeryTransactionModalState } from "@/app/core/context/ModalContext";
 import { BREAD_ADDRESS } from "@/constants";
 import { ERC20_ABI } from "@/abi";
 import { ReactNode } from "react";
-import { formatSupply } from "@/app/core/util/formatter";
+import { formatBalance, formatSupply } from "@/app/core/util/formatter";
 import { formatUnits } from "viem";
 import { useRefetchOnBlockChange } from "@/app/core/hooks/useRefetchOnBlockChange";
 import { useBlockNumber } from "wagmi";
+import { AddTokenButton } from "../../Header/AddTokenButton";
+import { useVaultAPY } from "@/app/core/hooks/useVaultAPY";
+import { useTokenBalances } from "@/app/core/context/TokenBalanceContext/TokenBalanceContext";
+import { renderFormattedDecimalNumber } from "@/app/core/util/render-formatted-decimal-number";
+import { LinkIcon } from "../../Icons/LinkIcon";
 function makeHeaderText(
   modalType: "BAKE" | "BURN",
   status: TTransactionStatus
@@ -48,7 +53,7 @@ function modalAdviceText(
     SAFE_SUBMITTED: "Safe Transaction Submitted",
     CONFIRMED:
       modalType === "BAKE"
-        ? "You have successfully baked"
+        ? "You successfully baked"
         : "Transaction Confirmed",
     REVERTED: "Transaction Reverted",
   };
@@ -121,6 +126,8 @@ export function BakeryTransactionModal({
 }: {
   modalState: BakeryTransactionModalState;
 }) {
+  const { data: APY } = useVaultAPY();
+  const { BREAD } = useTokenBalances();
   const { data: supply } = useRefetchOnBlockChange(
     BREAD_ADDRESS,
     ERC20_ABI,
@@ -175,6 +182,57 @@ export function BakeryTransactionModal({
     return Number(Number(amount).toFixed()) + parseInt(formatUnits(supply, 18));
   }
 
+  let pastBreadCoop = "0.00";
+  let additionalBreadCoop = "0.00";
+  let totalBreadCoop = "0.00";
+
+  if (
+    transaction.status === "CONFIRMED" &&
+    APY !== undefined &&
+    BREAD?.status === "SUCCESS"
+  ) {
+    totalBreadCoop = formatCoopValue(BREAD.value, APY);
+    additionalBreadCoop = formatCoopValue(transaction.data.value, APY);
+    pastBreadCoop = formatBalance(
+      parseFloat(totalBreadCoop) - parseFloat(additionalBreadCoop),
+      2
+    );
+  }
+
+  let middleContent: ReactNode;
+  if (
+    transaction.status === "CONFIRMED" &&
+    transaction.data.type === "BAKE"
+  ) {
+    middleContent = (
+      <>
+        <BakedBreadCoopInfo
+          txHash={transaction.hash!}
+          pastBreadCoop={pastBreadCoop}
+          additionalBreadCoop={additionalBreadCoop}
+          totalBreadCoop={totalBreadCoop}
+        />
+        <div className="mt-2 border border-status-success flex items-start justify-start rounded-xl p-4">
+          <div className="text-ultra-white mr-2">
+            <InfoBoxSvg />
+          </div>
+          <p className="text-breadgray-rye dark:text-breadgray-light-grey">
+            Baking $BREAD increases crucial funding for our
+            post-capitalist cooperatives.{" "}
+            <a
+              href="https://breadchain.notion.site/4d496b311b984bd9841ef9c192b9c1c7?v=2eb1762e6b83440f8b0556c9917f86ca"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-breadpink-shaded font-semibold border-b-2 border-dotted border-current"
+            >
+              How does this work?
+            </a>
+          </p>
+        </div>
+      </>
+    );
+  }
+
   let bottomContent: ReactNode;
   if (transaction.status === "PREPARED") {
     bottomContent = (
@@ -189,7 +247,7 @@ export function BakeryTransactionModal({
     bottomContent = (
       <>
         <ShareButtons newSupply={newSupply(transaction.data.value)} />
-        <div className="mb-1 h-0"></div>
+        <AddTokenButton className="!bg-transparent border-0" />
       </>
     );
   } else {
@@ -219,16 +277,132 @@ export function BakeryTransactionModal({
             transaction.status === "CONFIRMED" ? "mb-4" : ""
           } flex gap-2 items-center justify-center`}
         >
+          {transaction.status === "CONFIRMED" && transaction.data.type === "BAKE" && (
+            <span>
+              <BreadIcon />
+            </span>
+          )}
           <TransactionValue
             value={transaction.data.value ? transaction.data.value : "0"}
           />
-          <TokenLabelContainer>
-            <BreadIcon />
-            <TokenLabelText>BREAD</TokenLabelText>
-          </TokenLabelContainer>
+          {transaction.data.type !== "BAKE" && (
+            <TokenLabelContainer>
+              <BreadIcon />
+              <TokenLabelText>BREAD</TokenLabelText>
+            </TokenLabelContainer>
+          )}
         </div>
+        {middleContent}
         {bottomContent}
       </ModalContent>
     </ModalContainer>
   );
 }
+
+const BakedBreadCoopInfo = ({
+  txHash,
+  pastBreadCoop,
+  additionalBreadCoop,
+  totalBreadCoop,
+}: {
+  txHash: string;
+  pastBreadCoop: string;
+  additionalBreadCoop: string;
+  totalBreadCoop: string;
+}) => {
+  return (
+    <div className="w-full border border-breadgray-rye rounded-xl py-4 px-4">
+      <BakedBreadCoopInfoItem
+        label="Past annual Bread Coop funding"
+        amount={pastBreadCoop}
+        type="past"
+      />
+      <BakedBreadCoopInfoItem
+        label="Additional annual Bread Coop funding"
+        amount={additionalBreadCoop}
+        type="additional"
+      />
+      <BakedBreadCoopInfoItem
+        label="Total annual Bread Coop funding"
+        amount={totalBreadCoop}
+        type="total"
+      />
+      <p className="text-center mt-4 max-w-max mx-auto">
+        <a
+          href={`https://gnosisscan.io/tx/${txHash}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm flex items-center justify-center gap-1 text-breadpink-shaded"
+        >
+          <span className="mr-1">View on Gnosisscan</span>
+          <span>
+            <LinkIcon />
+          </span>
+        </a>
+      </p>
+    </div>
+  );
+};
+
+const BakedBreadCoopInfoItem = ({
+  label,
+  amount,
+  type,
+}: {
+  label: string;
+  amount: string;
+  type: "past" | "additional" | "total";
+}) => {
+  return (
+    <div className="flex items-center justify-between mb-2">
+      <p className="text-sm leading-normal text-breadgray-rye dark:text-breadgray-grey font-normal w-full">
+        {label}
+      </p>
+      <p className="flex items-center justify-end w-full max-w-max">
+        <span className="mr-2">
+          <BreadIcon />
+        </span>
+        <div className="inline-flex items-center justify-center">
+          <span
+            className={`inline-flex items-center justify-center ${
+              type === "additional"
+                ? "bread-pink-text-gradient"
+                : ""
+            }`}
+          >
+            {type === "additional" && <span>+</span>}
+            <span className="px-1">
+              {renderFormattedDecimalNumber(amount)}
+            </span>
+          </span>
+        </div>
+      </p>
+    </div>
+  );
+};
+
+const InfoBoxSvg = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M2.99951 3H4.99951V21H2.99951V3ZM18.9998 3.00003H5V5.00003H18.9998V19H5V21H19V21H20.9998V3H18.9998V3.00003ZM10.9998 9.00009H12.9998V7.00009H10.9998V9.00009ZM12.9998 17H10.9998V11H12.9998V17Z"
+      fill="currentcolor"
+    />
+  </svg>
+);
+
+const formatCoopValue = (breadValue: string, APY: bigint) => {
+  const calculatedValue =
+    parseFloat(breadValue) * Number(formatUnits(APY, 18));
+
+  const roundedValue = Number(calculatedValue.toFixed(2));
+
+  return formatBalance(roundedValue, 2);
+};

--- a/src/app/core/util/render-formatted-decimal-number.tsx
+++ b/src/app/core/util/render-formatted-decimal-number.tsx
@@ -1,0 +1,16 @@
+export const renderFormattedDecimalNumber = (number: string) => {
+  const part1 = number.split(".")[0];
+  const part2 = number.split(".")[1];
+
+  return (
+    <div className="w-full text-end flex tracking-wider text-lg text-breadgray-grey100 dark:text-breadgray-ultra-white leading-none">
+      <div className="flex gap-2 font-bold justify-end">
+        <span>{part1}</span>
+      </div>
+      <div>.</div>
+      <div className="text-sm font-semibold leading-[1.1] self-end">
+        {part2}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Closes: #264

Some info from the PR:
> Main changes are layout and more information:

> Past Bread Coop funding = If user already holding bread and displays the amount of yield they were donating before new bread is baked.
> Additional annual Bread Coop funding = Annual amount of yield is generated additionally using the newly baked BREAD amount with current DSR (APY) to calculate that.
> Total annual Bread Coop funding is the old + new funding amount summed up.

How do I get the values above? I saw the [useClaimableYield hook](https://github.com/BreadchainCoop/crowdstaking-v2/blob/main/src/app/governance/useClaimableYield.ts), but I don't know if it returns the "claimable yield" for the caller (`msg.sender`) or the contract.

Also, I can't access the dev mode on Figma because I'm not part of the team. Is there a way to fix this without joining or can I join?

@secbajor