### PR TITLE
temp fix: remove curve.fi URL

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,5 +5,4 @@ export const BREAD_ADDRESS = "0xa555d5344f6FB6c65da19e403Cb4c1eC4a1a5Ee3";
 export const BUTTER_ADDRESS = "0xf3d8f3de71657d342db60dd714c8a2ae37eac6b4";
 export const BUTTERED_BREAD_ADDRESS =
   "0x680B581605DC0A6902735a80dE35Cb0Ef6E90865";
-export const CURVE_SWAP_URL =
-  "https://curve.fi/dex/xdai/pools/factory-stable-ng-15/swap/";
+export const CURVE_SWAP_URL = '' // "https://curve.fi/dex/xdai/pools/factory-stable-ng-15/swap/";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,4 +5,4 @@ export const BREAD_ADDRESS = "0xa555d5344f6FB6c65da19e403Cb4c1eC4a1a5Ee3";
 export const BUTTER_ADDRESS = "0xf3d8f3de71657d342db60dd714c8a2ae37eac6b4";
 export const BUTTERED_BREAD_ADDRESS =
   "0x680B581605DC0A6902735a80dE35Cb0Ef6E90865";
-export const CURVE_SWAP_URL = '' // "https://curve.fi/dex/xdai/pools/factory-stable-ng-15/swap/";
+export const CURVE_SWAP_URL = "https://www.curve.finance/dex/xdai/pools/factory-stable-ng-15/swap/";


### PR DESCRIPTION
"Seems like curve.fi DNS might be hijacked" (https://invezz.com/news/2025/05/13/crv-token-plunges-as-curve-finances-dns-breach-rattles-investors/)