### PR TITLE
fix: rename "Bread Crowdstaking" → "Bread Solidarity Fund" across site metadata

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "Bread Crowdstaking",
-  "description": "Bake and Burn BREAD",
-  "short_name": "Bread Crowdstaking",
+  "name": "Bread Solidarity Fund",
+  "description": "Pool yield. Fund solidarity. Bread Cooperative's community-governed fund.",
+  "short_name": "Bread Solidarity Fund",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",

--- a/src/lib/peer.ts
+++ b/src/lib/peer.ts
@@ -1,6 +1,6 @@
 export const peerConfig = {
   baseUrl: "https://peer.xyz/swap",
-  referrer: "Bread Crowdstaking",
+  referrer: "Bread Solidarity Fund",
   referrerLogo: "https://fund.bread.coop/logo.svg",
   // xDAI on Gnosis Chain (chainId: 100, native token)
   toToken: "100:0x0000000000000000000000000000000000000000",

--- a/src/lib/site-metadata.ts
+++ b/src/lib/site-metadata.ts
@@ -14,15 +14,16 @@ type MetadataConfig = {
 };
 
 const DEFAULT_METADATA = {
-  title: "Bread Crowdstaking",
-  description: "Bake and burn BREAD. Fund post-capitalist web3.",
+  title: "Bread Solidarity Fund",
+  description:
+    "The Bread Solidarity Fund pools stablecoin yield to democratically fund post-capitalist web3 projects.",
   url: "https://fund.bread.coop/",
-  siteName: "Bread Crowdstaking",
+  siteName: "Bread Solidarity Fund",
   image: {
     url: "https://bread.coop/preview.png?v=33",
     width: 2048,
     height: 1536,
-    alt: "Bread Crowdstaking",
+    alt: "Bread Solidarity Fund",
   },
 } as const;
 


### PR DESCRIPTION
## Summary

Fixes the browser tab title, OG/Twitter card metadata, PWA manifest, and peer referrer — all of which still read "Bread Crowdstaking" instead of "Bread Solidarity Fund".

Closes #410

## Changes

- **`src/lib/site-metadata.ts`** — Updated `title`, `siteName`, and `image.alt` to "Bread Solidarity Fund". Also improved the `description` for better SEO and social sharing previews.
- **`public/manifest.json`** — Updated `name` and `short_name` to "Bread Solidarity Fund". Improved PWA `description`.
- **`src/lib/peer.ts`** — Updated `referrer` to "Bread Solidarity Fund".

## SEO Impact

Since OG and Twitter card tags are generated from `DEFAULT_METADATA` in `site-metadata.ts`, this single change fixes all social sharing previews automatically. The improved description will also help search snippet quality.

## Test Plan

- [ ] Browser tab reads "Bread Solidarity Fund" on fund.bread.coop
- [ ] OG/Twitter card preview shows correct title (check with e.g. https://opengraph.xyz)
- [ ] PWA install prompt shows "Bread Solidarity Fund"
- [ ] Peer.xyz swap widget referrer is updated