### PR TITLE
fix: poll Safe Wallet transactions to unblock LP unlock (and all Safe txs)

### DIFF
--- a/src/app/core/context/TransactionsContext/SafeTransactionWatcher.tsx
+++ b/src/app/core/context/TransactionsContext/SafeTransactionWatcher.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from "react";
+import SafeAppsSDK, { TransactionStatus } from "@safe-global/safe-apps-sdk";
+import {
+  TSafeTransactionSubmitted,
+  TTransactionsDispatch,
+} from "./TransactionsReducer";
+import { useToast } from "../ToastContext/ToastContext";
+
+const POLL_INTERVAL_MS = 3000;
+
+/**
+ * Watches a Safe Wallet transaction by polling getBySafeTxHash every
+ * POLL_INTERVAL_MS milliseconds. Safe transactions don't resolve
+ * synchronously — they require multi-sig confirmation and return a
+ * safeTxHash instead of a regular on-chain txHash. Without this
+ * watcher, SAFE_SUBMITTED transactions get stuck "in process" forever.
+ */
+export function SafeTransactionWatcher({
+  transaction,
+  transactionsDispatch,
+}: {
+  transaction: TSafeTransactionSubmitted;
+  transactionsDispatch: TTransactionsDispatch;
+}) {
+  const { hash } = transaction;
+  const { toastDispatch } = useToast();
+  const sdkRef = useRef(new SafeAppsSDK());
+
+  useEffect(() => {
+    toastDispatch({
+      type: "NEW",
+      payload: { toastType: "SUBMITTED", txHash: hash },
+    });
+  }, [hash, toastDispatch]);
+
+  useEffect(() => {
+    const sdk = sdkRef.current;
+    let intervalId: ReturnType<typeof setInterval>;
+
+    const poll = async () => {
+      try {
+        const tx = await sdk.txs.getBySafeTxHash(hash as string);
+
+        if (tx.txStatus === TransactionStatus.SUCCESS) {
+          transactionsDispatch({
+            type: "SET_SUCCESS",
+            payload: { hash: hash as string },
+          });
+          clearInterval(intervalId);
+        } else if (
+          tx.txStatus === TransactionStatus.CANCELLED ||
+          tx.txStatus === TransactionStatus.FAILED
+        ) {
+          transactionsDispatch({
+            type: "SET_REVERTED",
+            payload: { hash: hash as string },
+          });
+          toastDispatch({
+            type: "NEW",
+            payload: { toastType: "REVERTED", txHash: hash as string },
+          });
+          clearInterval(intervalId);
+        }
+        // AWAITING_CONFIRMATIONS and AWAITING_EXECUTION are non-terminal;
+        // keep polling.
+      } catch {
+        // SDK call failed — tx may not be indexed yet; keep polling.
+      }
+    };
+
+    poll();
+    intervalId = setInterval(poll, POLL_INTERVAL_MS);
+
+    return () => clearInterval(intervalId);
+  }, [hash, transactionsDispatch, toastDispatch]);
+
+  return null;
+}

--- a/src/app/core/context/TransactionsContext/SafeTransactionWatcher.tsx
+++ b/src/app/core/context/TransactionsContext/SafeTransactionWatcher.tsx
@@ -23,15 +23,16 @@ export function SafeTransactionWatcher({
   transactionsDispatch: TTransactionsDispatch;
 }) {
   const { hash } = transaction;
+  const typedHash = hash as `0x${string}`;
   const { toastDispatch } = useToast();
   const sdkRef = useRef(new SafeAppsSDK());
 
   useEffect(() => {
     toastDispatch({
       type: "NEW",
-      payload: { toastType: "SUBMITTED", txHash: hash },
+      payload: { toastType: "SUBMITTED", txHash: typedHash },
     });
-  }, [hash, toastDispatch]);
+  }, [typedHash, toastDispatch]);
 
   useEffect(() => {
     const sdk = sdkRef.current;
@@ -39,12 +40,12 @@ export function SafeTransactionWatcher({
 
     const poll = async () => {
       try {
-        const tx = await sdk.txs.getBySafeTxHash(hash as string);
+        const tx = await sdk.txs.getBySafeTxHash(typedHash);
 
         if (tx.txStatus === TransactionStatus.SUCCESS) {
           transactionsDispatch({
             type: "SET_SUCCESS",
-            payload: { hash: hash as string },
+            payload: { hash: typedHash },
           });
           clearInterval(intervalId);
         } else if (
@@ -53,11 +54,11 @@ export function SafeTransactionWatcher({
         ) {
           transactionsDispatch({
             type: "SET_REVERTED",
-            payload: { hash: hash as string },
+            payload: { hash: typedHash },
           });
           toastDispatch({
             type: "NEW",
-            payload: { toastType: "REVERTED", txHash: hash as string },
+            payload: { toastType: "REVERTED", txHash: typedHash },
           });
           clearInterval(intervalId);
         }
@@ -72,7 +73,7 @@ export function SafeTransactionWatcher({
     intervalId = setInterval(poll, POLL_INTERVAL_MS);
 
     return () => clearInterval(intervalId);
-  }, [hash, transactionsDispatch, toastDispatch]);
+  }, [typedHash, transactionsDispatch, toastDispatch]);
 
   return null;
 }

--- a/src/app/core/context/TransactionsContext/TransactionsContext.tsx
+++ b/src/app/core/context/TransactionsContext/TransactionsContext.tsx
@@ -11,6 +11,7 @@ import {
   TransactionsReducer,
 } from "./TransactionsReducer";
 import { TransactionWatcher } from "./TransactionsWatcher";
+import { SafeTransactionWatcher } from "./SafeTransactionWatcher";
 
 const TransactionsContext = createContext<
   | {
@@ -33,15 +34,27 @@ function TransactionsProvider({ children }: { children: ReactNode }) {
 
   return (
     <TransactionsContext.Provider value={value}>
-      {value.transactionsState.submitted.map((transaction) =>
-        transaction.status === "SUBMITTED" ? (
-          <TransactionWatcher
-            key={`watching_transaction_${transaction.hash}`}
-            transaction={transaction}
-            transactionsDispatch={value.transactionsDispatch}
-          />
-        ) : null
-      )}
+      {value.transactionsState.submitted.map((transaction) => {
+        if (transaction.status === "SUBMITTED") {
+          return (
+            <TransactionWatcher
+              key={`watching_transaction_${transaction.hash}`}
+              transaction={transaction}
+              transactionsDispatch={value.transactionsDispatch}
+            />
+          );
+        }
+        if (transaction.status === "SAFE_SUBMITTED") {
+          return (
+            <SafeTransactionWatcher
+              key={`watching_safe_transaction_${transaction.hash}`}
+              transaction={transaction}
+              transactionsDispatch={value.transactionsDispatch}
+            />
+          );
+        }
+        return null;
+      })}
       {children}
     </TransactionsContext.Provider>
   );


### PR DESCRIPTION
## Summary\n\nFixes #408 — users couldn't unlock LP tokens (or complete any transaction) when using Safe Wallet. The UI would get stuck "in process" forever.\n\n## Root Cause\n\nSafe Wallet doesn't resolve transactions synchronously. Instead of returning a regular on-chain `txHash`, it returns a `safeTxHash` that requires multi-sig confirmation before execution. \n\nThe existing `TransactionWatcher` uses wagmi's `useWaitForTransactionReceipt`, which **doesn't work with `safeTxHash`**. `SAFE_SUBMITTED` transactions had no watcher at all — so they were stuck in that state indefinitely.\n\n## Fix\n\n**New file: `SafeTransactionWatcher.tsx`**\n- Polls `safeSdk.txs.getBySafeTxHash(hash)` every 3 seconds\n- On `SUCCESS` → dispatches `SET_SUCCESS`\n- On `CANCELLED` or `FAILED` → dispatches `SET_REVERTED` + shows reverted toast\n- Non-terminal states (`AWAITING_CONFIRMATIONS`, `AWAITING_EXECUTION`) keep polling\n- SDK errors are silently swallowed (tx may not be indexed yet)\n\n**Updated: `TransactionsContext.tsx`**\n- Renders `SafeTransactionWatcher` for `SAFE_SUBMITTED` transactions alongside the existing `TransactionWatcher` for regular `SUBMITTED` ones\n\n## Scope\n\nThis fix covers **all Safe Wallet transactions** in the app (LP unlock, bake, burn, vote, deposit, allowance) since they all use the same `SAFE_SUBMITTED` status path.\n\n## Test Plan\n\n- [ ] Connect Safe Wallet via WalletConnect\n- [ ] Trigger LP token unlock — confirm the modal progresses past "in process" after Safe signers confirm\n- [ ] Test with a Safe that requires multiple signers — confirm UI waits correctly and resolves on execution\n- [ ] Test rejection in Safe — confirm UI shows reverted state\n- [ ] Verify regular (non-Safe) wallet transactions still work normally