### PR TITLE
chore: add design issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/design.md
+++ b/.github/ISSUE_TEMPLATE/design.md
@@ -1,0 +1,49 @@
+---
+name: Design Issue
+about: New UI/UX feature or improvement — structured for AI-assisted design and development
+title: "[Design] "
+labels: "design: needs figma"
+assignees: ""
+---
+
+## Problem
+<!-- What UX problem does this solve and why does it matter? -->
+
+## User Flow
+<!-- Step-by-step numbered flow. Cover happy path + error states. -->
+1. User lands on [page]
+2. User sees [element] and clicks [action]
+3. System responds with [state]
+4. User completes [goal]
+
+## Screens & States Required
+- [ ] Default / empty state
+- [ ] Loading state
+- [ ] Filled / active state
+- [ ] Error state
+- [ ] Mobile breakpoint
+- [ ] Dark mode (if applicable)
+
+## Design System References
+<!-- List DS components, colors, typography, and icons to use -->
+- **Components:** e.g. LiftedButton (per-app variant), InputField, Modal
+- **Colors:** e.g. $bread-yellow, $background-dark
+- **Typography:** e.g. .text-h2 for heading, .text-body for copy
+- **Icons:** e.g. Phosphor — ArrowRight, Wallet
+- **Figma DS file:** OYtf96ROFhou9nHezG5SOD
+
+## Target Figma File
+<!-- Which Figma file and page should designs be added to? -->
+- **File key:** 
+- **Page:** 
+
+## Acceptance Criteria
+- [ ] All states above are designed
+- [ ] Uses DS components only (no custom atoms)
+- [ ] Reviewed and approved at weekly design meeting
+- [ ] Matches existing app grid and spacing
+- [ ] Figma link added to this issue before moving to dev
+
+## App & Repo
+- **App:** Solidarity Fund
+- **Repo:** BreadchainCoop/crowdstaking-v2


### PR DESCRIPTION
Adds `.github/ISSUE_TEMPLATE/design.md` — a structured Claude Code-ready design brief template for new UI/UX issues. Part of the Bread Coop AI-native design workflow setup.

Auto-applies the `design: needs figma` label and prompts for problem statement, user flow, screen/state inventory, DS references, and acceptance criteria.