### PR TITLE
feat: visual Solidarity Fund hero (showcase for #394)

### DIFF
--- a/public/avatars/member-1.svg
+++ b/public/avatars/member-1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" width="80" height="80">
+<rect width="80" height="80" fill="#F4DFC9"/>
+<path d="M14 80 C14 63 30 56 40 56 C50 56 66 63 66 80 Z" fill="#EA5817"/>
+<rect x="35.5" y="47" width="9" height="12" rx="4" fill="#F2D6B3"/>
+<circle cx="40" cy="38" r="15" fill="#F2D6B3"/>
+<path d="M23 38 C23 23 57 23 57 38 C57 31 50 27 40 27 C30 27 23 31 23 38 Z" fill="#3A2A1A"/>
+<circle cx="34.5" cy="39" r="1.7" fill="#3a2a1a"/>
+<circle cx="45.5" cy="39" r="1.7" fill="#3a2a1a"/>
+<path d="M35 44.5 Q40 48.5 45 44.5" stroke="#3a2a1a" stroke-width="1.6" fill="none" stroke-linecap="round"/>
+</svg>

--- a/public/avatars/member-2.svg
+++ b/public/avatars/member-2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" width="80" height="80">
+<rect width="80" height="80" fill="#CBE9E6"/>
+<path d="M14 80 C14 63 30 56 40 56 C50 56 66 63 66 80 Z" fill="#1C5BB9"/>
+<rect x="35.5" y="47" width="9" height="12" rx="4" fill="#C68642"/>
+<circle cx="40" cy="38" r="15" fill="#C68642"/>
+<circle cx="40" cy="20" r="6" fill="#241C16"/><path d="M24 38 C24 25 56 25 56 38 C56 32 49 28 40 28 C31 28 24 32 24 38 Z" fill="#241C16"/>
+<circle cx="34.5" cy="39" r="1.7" fill="#3a2a1a"/>
+<circle cx="45.5" cy="39" r="1.7" fill="#3a2a1a"/>
+<path d="M35 44.5 Q40 48.5 45 44.5" stroke="#3a2a1a" stroke-width="1.6" fill="none" stroke-linecap="round"/>
+</svg>

--- a/public/avatars/member-3.svg
+++ b/public/avatars/member-3.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" width="80" height="80">
+<rect width="80" height="80" fill="#A8C3EA"/>
+<path d="M14 80 C14 63 30 56 40 56 C50 56 66 63 66 80 Z" fill="#60A29A"/>
+<rect x="35.5" y="47" width="9" height="12" rx="4" fill="#8D5524"/>
+<circle cx="40" cy="38" r="15" fill="#8D5524"/>
+<g fill="#171717"><circle cx="28" cy="28" r="7"/><circle cx="40" cy="23" r="8"/><circle cx="52" cy="28" r="7"/><circle cx="24" cy="36" r="5"/><circle cx="56" cy="36" r="5"/></g>
+<circle cx="34.5" cy="39" r="1.7" fill="#3a2a1a"/>
+<circle cx="45.5" cy="39" r="1.7" fill="#3a2a1a"/>
+<path d="M35 44.5 Q40 48.5 45 44.5" stroke="#3a2a1a" stroke-width="1.6" fill="none" stroke-linecap="round"/>
+</svg>

--- a/public/avatars/member-4.svg
+++ b/public/avatars/member-4.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" width="80" height="80">
+<rect width="80" height="80" fill="#FBDED1"/>
+<path d="M14 80 C14 63 30 56 40 56 C50 56 66 63 66 80 Z" fill="#EA5817"/>
+<rect x="35.5" y="47" width="9" height="12" rx="4" fill="#E0AC85"/>
+<circle cx="40" cy="38" r="15" fill="#E0AC85"/>
+<path d="M22 52 C20 34 26 24 40 24 C54 24 60 34 58 52 C56 44 54 38 54 36 C54 30 48 27 40 27 C32 27 26 30 26 36 C26 38 24 44 22 52 Z" fill="#6B4423"/>
+<circle cx="34.5" cy="39" r="1.7" fill="#3a2a1a"/>
+<circle cx="45.5" cy="39" r="1.7" fill="#3a2a1a"/>
+<path d="M35 44.5 Q40 48.5 45 44.5" stroke="#3a2a1a" stroke-width="1.6" fill="none" stroke-linecap="round"/>
+</svg>

--- a/public/avatars/member-5.svg
+++ b/public/avatars/member-5.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" width="80" height="80">
+<rect width="80" height="80" fill="#EFE7D6"/>
+<path d="M14 80 C14 63 30 56 40 56 C50 56 66 63 66 80 Z" fill="#1C5BB9"/>
+<rect x="35.5" y="47" width="9" height="12" rx="4" fill="#FFE0BD"/>
+<circle cx="40" cy="38" r="15" fill="#FFE0BD"/>
+<path d="M23 38 C23 23 57 23 57 38 C57 31 50 27 40 27 C30 27 23 31 23 38 Z" fill="#D9A441"/>
+<circle cx="34.5" cy="39" r="1.7" fill="#3a2a1a"/>
+<circle cx="45.5" cy="39" r="1.7" fill="#3a2a1a"/>
+<path d="M35 44.5 Q40 48.5 45 44.5" stroke="#3a2a1a" stroke-width="1.6" fill="none" stroke-linecap="round"/>
+</svg>

--- a/public/avatars/member-6.svg
+++ b/public/avatars/member-6.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" width="80" height="80">
+<rect width="80" height="80" fill="#F7CAC2"/>
+<path d="M14 80 C14 63 30 56 40 56 C50 56 66 63 66 80 Z" fill="#60A29A"/>
+<rect x="35.5" y="47" width="9" height="12" rx="4" fill="#A86B3C"/>
+<circle cx="40" cy="38" r="15" fill="#A86B3C"/>
+<circle cx="40" cy="20" r="6" fill="#2B2B2B"/><path d="M24 38 C24 25 56 25 56 38 C56 32 49 28 40 28 C31 28 24 32 24 38 Z" fill="#2B2B2B"/>
+<circle cx="34.5" cy="39" r="1.7" fill="#3a2a1a"/>
+<circle cx="45.5" cy="39" r="1.7" fill="#3a2a1a"/>
+<path d="M35 44.5 Q40 48.5 45 44.5" stroke="#3a2a1a" stroke-width="1.6" fill="none" stroke-linecap="round"/>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "Bread Crowdstaking",
-  "description": "Bake and Burn BREAD",
-  "short_name": "Bread Crowdstaking",
+  "name": "Bread Solidarity Fund",
+  "description": "Pool yield. Fund solidarity. Bread Cooperative's community-governed fund.",
+  "short_name": "Bread Solidarity Fund",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",

--- a/src/abi/ButteredBread.ts
+++ b/src/abi/ButteredBread.ts
@@ -702,4 +702,13 @@ export const butteredBreadAbi = [
     name: "VotesExpiredSignature",
     inputs: [{ name: "expiry", type: "uint256", internalType: "uint256" }],
   },
+  {
+    type: "error",
+    name: "ERC20InsufficientBalance",
+    inputs: [
+      { name: "sender", type: "address", internalType: "address" },
+      { name: "balance", type: "uint256", internalType: "uint256" },
+      { name: "needed", type: "uint256", internalType: "uint256" },
+    ],
+  },
 ] as const;

--- a/src/app/bakery/components/SolidarityHero.tsx
+++ b/src/app/bakery/components/SolidarityHero.tsx
@@ -73,12 +73,6 @@ export function SolidarityHero() {
 		});
 	};
 
-	const handleHowItWorks = () => {
-		document
-			.getElementById("how-it-works")
-			?.scrollIntoView({ behavior: "smooth", block: "start" });
-	};
-
 	return (
 		<section className="grid items-center gap-10 py-8 md:grid-cols-2 md:gap-x-6 lg:gap-x-[6rem] md:py-14">
 			{/* ── Left: slogan + CTAs ── */}
@@ -96,11 +90,16 @@ export function SolidarityHero() {
 							Support fund
 						</LiftedButton>
 					</div>
-					<div className="lifted-button-container">
-						<LiftedButton preset="secondary" onClick={handleHowItWorks}>
+					<a
+						href="https://docs.bread.coop/about/bread-token/"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="lifted-button-container"
+					>
+						<LiftedButton preset="secondary">
 							How it works →
 						</LiftedButton>
-					</div>
+					</a>
 				</div>
 			</div>
 

--- a/src/app/bakery/components/SolidarityHero.tsx
+++ b/src/app/bakery/components/SolidarityHero.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { blo } from "blo";
 import { formatUnits } from "viem";
 import { useQuery } from "@tanstack/react-query";
 import { Body, Heading1, LiftedButton } from "@breadcoop/ui";
@@ -19,15 +18,15 @@ const ACTIVE_PROJECTS = Object.values(projectsMeta)
 const HERO_PROJECTS = ACTIVE_PROJECTS.slice(0, 5);
 const MORE_PROJECTS = ACTIVE_PROJECTS.length - HERO_PROJECTS.length;
 
-// Decorative, deterministic identicons standing in for the community of
+// Decorative, diverse member illustrations standing in for the community of
 // backers. The real headcount is the number; these just make it a picture.
-const AVATAR_SEEDS = [
-	"0x4a1f8e2b9c0d7e6f5a3b2c1d0e9f8a7b6c5d4e3f",
-	"0x7c3d9a1b2e4f6a8c0d2e4f6a8b0c2d4e6f8a0b2c",
-	"0x9e8d7c6b5a4f3e2d1c0b9a8f7e6d5c4b3a2f1e0d",
-	"0x2b4d6f8a0c2e4f6a8b0d2f4a6c8e0b2d4f6a8c0e",
-	"0xf0e1d2c3b4a5968778695a4b3c2d1e0f0a1b2c3d",
-	"0x5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b",
+const MEMBER_AVATARS = [
+	"/avatars/member-1.svg",
+	"/avatars/member-2.svg",
+	"/avatars/member-3.svg",
+	"/avatars/member-4.svg",
+	"/avatars/member-5.svg",
+	"/avatars/member-6.svg",
 ] as const;
 
 const FALLBACK_BREAD_BACKERS = 209;
@@ -108,11 +107,11 @@ export function SolidarityHero() {
 				<div>
 					<div className="flex items-center">
 						<div className="flex">
-							{AVATAR_SEEDS.map((seed) => (
+							{MEMBER_AVATARS.map((src) => (
 								// eslint-disable-next-line @next/next/no-img-element
 								<img
-									key={seed}
-									src={blo(seed)}
+									key={src}
+									src={src}
 									alt=""
 									className="size-10 rounded-full border-2 border-paper-main -ml-3 first:ml-0 shadow-sm"
 								/>

--- a/src/app/bakery/components/SolidarityHero.tsx
+++ b/src/app/bakery/components/SolidarityHero.tsx
@@ -10,7 +10,14 @@ import AnimatedNumber from "@/app/components/animated-number";
 import { useModal } from "@/app/core/context/ModalContext";
 import { FALLBACK_APY_VALUE, useVaultAPY } from "@/app/core/hooks/useVaultAPY";
 import { formatSupply } from "@/app/core/util/formatter";
-import { memberProjects } from "@/app/governance/projectData";
+import { projectsMeta } from "@/app/projectsMeta";
+
+// Same project metadata + logos the governance page uses, active first.
+const ACTIVE_PROJECTS = Object.values(projectsMeta)
+	.filter((p) => p.active)
+	.sort((a, b) => a.order - b.order);
+const HERO_PROJECTS = ACTIVE_PROJECTS.slice(0, 5);
+const MORE_PROJECTS = ACTIVE_PROJECTS.length - HERO_PROJECTS.length;
 
 // Decorative, deterministic identicons standing in for the community of
 // backers. The real headcount is the number; these just make it a picture.
@@ -22,14 +29,6 @@ const AVATAR_SEEDS = [
 	"0xf0e1d2c3b4a5968778695a4b3c2d1e0f0a1b2c3d",
 	"0x5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b",
 ] as const;
-
-const TILE_COLORS = [
-	"bg-primary-orange",
-	"bg-[#60A29A]", // jade
-	"bg-primary-blue",
-	"bg-[#EA5817]",
-	"bg-[#1B201A]",
-];
 
 const FALLBACK_BREAD_BACKERS = 209;
 const FALLBACK_TOTAL_FUNDING = 46548;
@@ -62,7 +61,7 @@ export function SolidarityHero() {
 		},
 	});
 
-	const projectCount = memberProjects.length;
+	const projectCount = ACTIVE_PROJECTS.length;
 
 	const handleSupport = () => {
 		setModal({
@@ -132,26 +131,31 @@ export function SolidarityHero() {
 					</Body>
 				</div>
 
-				{/* Projects — colored tiles */}
+				{/* Projects — real logos from the governance page */}
 				<div>
 					<div className="flex gap-2">
-						{memberProjects.map((project, i) => (
+						{HERO_PROJECTS.map((project) => (
 							<div
-								key={project.id}
+								key={project.name}
 								title={project.name}
-								className={`flex size-12 items-center justify-center font-breadDisplay font-black text-xl text-white ${
-									TILE_COLORS[i % TILE_COLORS.length]
-								}`}
+								className="flex size-12 items-center justify-center overflow-hidden border border-[#eae2d6] bg-white"
 							>
-								{project.name.charAt(0)}
+								{/* eslint-disable-next-line @next/next/no-img-element */}
+								<img
+									src={`/${project.logoSrc}`}
+									alt={`${project.name} logo`}
+									className="size-full object-contain p-1.5"
+								/>
 							</div>
 						))}
-						<div className="flex size-12 items-center justify-center border border-dashed border-surface-grey text-surface-grey font-breadDisplay font-bold">
-							+
-						</div>
+						{MORE_PROJECTS > 0 && (
+							<div className="flex size-12 items-center justify-center border border-dashed border-surface-grey text-surface-grey font-breadDisplay font-bold">
+								+{MORE_PROJECTS}
+							</div>
+						)}
 					</div>
 					<Body className="mt-2 text-surface-grey">
-						{projectCount}+ projects funded, chosen by the community
+						{projectCount} projects, chosen by the community
 					</Body>
 				</div>
 

--- a/src/app/bakery/components/SolidarityHero.tsx
+++ b/src/app/bakery/components/SolidarityHero.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { blo } from "blo";
+import { formatUnits } from "viem";
+import { useQuery } from "@tanstack/react-query";
+import { Body, Heading1, LiftedButton } from "@breadcoop/ui";
+
+import SwapWrapper from "@/app/components/SwapWrapper";
+import AnimatedNumber from "@/app/components/animated-number";
+import { useModal } from "@/app/core/context/ModalContext";
+import { FALLBACK_APY_VALUE, useVaultAPY } from "@/app/core/hooks/useVaultAPY";
+import { formatSupply } from "@/app/core/util/formatter";
+import { memberProjects } from "@/app/governance/projectData";
+
+// Decorative, deterministic identicons standing in for the community of
+// backers. The real headcount is the number; these just make it a picture.
+const AVATAR_SEEDS = [
+	"0x4a1f8e2b9c0d7e6f5a3b2c1d0e9f8a7b6c5d4e3f",
+	"0x7c3d9a1b2e4f6a8c0d2e4f6a8b0c2d4e6f8a0b2c",
+	"0x9e8d7c6b5a4f3e2d1c0b9a8f7e6d5c4b3a2f1e0d",
+	"0x2b4d6f8a0c2e4f6a8b0d2f4a6c8e0b2d4f6a8c0e",
+	"0xf0e1d2c3b4a5968778695a4b3c2d1e0f0a1b2c3d",
+	"0x5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b",
+] as const;
+
+const TILE_COLORS = [
+	"bg-primary-orange",
+	"bg-[#60A29A]", // jade
+	"bg-primary-blue",
+	"bg-[#EA5817]",
+	"bg-[#1B201A]",
+];
+
+const FALLBACK_BREAD_BACKERS = 209;
+const FALLBACK_TOTAL_FUNDING = 46548;
+
+const apyFormatter = (v: number) => v.toFixed(1);
+
+export function SolidarityHero() {
+	const { setModal } = useModal();
+
+	const { data: apyData = FALLBACK_APY_VALUE } = useVaultAPY();
+	const apy = Number(formatUnits(apyData, 18)) * 100;
+
+	const { data: backers = FALLBACK_BREAD_BACKERS } = useQuery({
+		queryKey: ["bread-backers"],
+		queryFn: async () => {
+			const res = (await (await fetch("/api/bread-backers")).json()) as {
+				_col0: number;
+			};
+			return res._col0;
+		},
+	});
+
+	const { data: funding = FALLBACK_TOTAL_FUNDING } = useQuery({
+		queryKey: ["total-bread-distributed"],
+		queryFn: async () => {
+			const res = (await (
+				await fetch("/api/total-bread-distributed")
+			).json()) as { _col0: number };
+			return res._col0;
+		},
+	});
+
+	const projectCount = memberProjects.length;
+
+	const handleSupport = () => {
+		setModal({
+			type: "GENERIC_MODAL",
+			showCloseButton: false,
+			includeContainerStyling: false,
+			children: <SwapWrapper />,
+		});
+	};
+
+	const handleHowItWorks = () => {
+		document
+			.getElementById("how-it-works")
+			?.scrollIntoView({ behavior: "smooth", block: "start" });
+	};
+
+	return (
+		<section className="grid items-center gap-10 py-8 md:grid-cols-2 md:gap-x-6 lg:gap-x-[6rem] md:py-14">
+			{/* ── Left: slogan + CTAs ── */}
+			<div>
+				<Heading1 className="text-[2.5rem] text-primary-orange mb-4 md:flex md:flex-col md:leading-[0.9] md:text-[3.5rem] lg:text-[4.5rem]">
+					<span>THE</span> <span>SOLIDARITY</span> <span>FUND</span>
+				</Heading1>
+				<Body className="font-breadDisplay text-surface-grey-2 text-lg mb-8 md:max-w-[24rem]">
+					Give without giving. Your savings stay yours — only the
+					interest funds the work.
+				</Body>
+				<div className="flex flex-wrap items-center gap-4">
+					<div className="lifted-button-container">
+						<LiftedButton onClick={handleSupport}>
+							Support fund
+						</LiftedButton>
+					</div>
+					<div className="lifted-button-container">
+						<LiftedButton preset="secondary" onClick={handleHowItWorks}>
+							How it works →
+						</LiftedButton>
+					</div>
+				</div>
+			</div>
+
+			{/* ── Right: the data, as pictures ── */}
+			<div className="flex flex-col gap-8">
+				{/* Backers — avatar cluster */}
+				<div>
+					<div className="flex items-center">
+						<div className="flex">
+							{AVATAR_SEEDS.map((seed) => (
+								// eslint-disable-next-line @next/next/no-img-element
+								<img
+									key={seed}
+									src={blo(seed)}
+									alt=""
+									className="size-10 rounded-full border-2 border-paper-main -ml-3 first:ml-0 shadow-sm"
+								/>
+							))}
+						</div>
+						<span className="ml-3 flex items-center font-breadDisplay font-black text-2xl text-surface-ink">
+							+
+							<AnimatedNumber
+								value={backers}
+								formatter={(v) => v.toFixed(0)}
+							/>
+						</span>
+					</div>
+					<Body className="mt-2 text-surface-grey">
+						neighbours bake &amp; back the fund together
+					</Body>
+				</div>
+
+				{/* Projects — colored tiles */}
+				<div>
+					<div className="flex gap-2">
+						{memberProjects.map((project, i) => (
+							<div
+								key={project.id}
+								title={project.name}
+								className={`flex size-12 items-center justify-center font-breadDisplay font-black text-xl text-white ${
+									TILE_COLORS[i % TILE_COLORS.length]
+								}`}
+							>
+								{project.name.charAt(0)}
+							</div>
+						))}
+						<div className="flex size-12 items-center justify-center border border-dashed border-surface-grey text-surface-grey font-breadDisplay font-bold">
+							+
+						</div>
+					</div>
+					<Body className="mt-2 text-surface-grey">
+						{projectCount}+ projects funded, chosen by the community
+					</Body>
+				</div>
+
+				{/* APY ring + subtle funding accent */}
+				<div className="flex flex-wrap items-center gap-x-8 gap-y-4">
+					<div className="flex items-center gap-3">
+						<ApyRing apy={apy} />
+						<div className="leading-tight">
+							<p className="font-breadDisplay font-black text-2xl text-surface-ink">
+								<AnimatedNumber
+									value={apy}
+									formatter={apyFormatter}
+								/>
+								%
+							</p>
+							<Body className="text-surface-grey text-sm">
+								earning APY
+							</Body>
+						</div>
+					</div>
+
+					<div className="leading-tight">
+						<p className="font-breadDisplay font-black text-2xl text-surface-ink">
+							<AnimatedNumber
+								value={funding}
+								formatter={formatSupply}
+							/>{" "}
+							<span className="text-primary-orange">$BREAD</span>
+						</p>
+						<Body className="text-surface-grey text-sm">
+							given to the work, so far
+						</Body>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}
+
+/** Small decorative donut ring with the APY arc. */
+function ApyRing({ apy }: { apy: number }) {
+	const r = 26;
+	const c = 2 * Math.PI * r;
+	// Cap the visual arc at ~15% so the ring reads nicely at typical rates.
+	const pct = Math.max(0.06, Math.min(apy / 15, 1));
+	return (
+		<svg width="64" height="64" viewBox="0 0 64 64" className="shrink-0">
+			<circle
+				cx="32"
+				cy="32"
+				r={r}
+				fill="none"
+				stroke="#F4DFC9"
+				strokeWidth="6"
+			/>
+			<circle
+				cx="32"
+				cy="32"
+				r={r}
+				fill="none"
+				stroke="#EA5817"
+				strokeWidth="6"
+				strokeLinecap="round"
+				strokeDasharray={c}
+				strokeDashoffset={c * (1 - pct)}
+				transform="rotate(-90 32 32)"
+			/>
+		</svg>
+	);
+}

--- a/src/app/components/nav/nav-solidarity-apps.tsx
+++ b/src/app/components/nav/nav-solidarity-apps.tsx
@@ -12,7 +12,7 @@ const _apps = [
 	{
 		id: "fund",
 		label: "Solidarity Fund",
-		desc: "Fund post-capitalism",
+		desc: "give without giving.",
 		color: "text-[#EA5817]",
 		comingSoon: false,
 	},

--- a/src/app/core/components/Modal/LPVaultTransactionModal/LPVaultTransactionModal.tsx
+++ b/src/app/core/components/Modal/LPVaultTransactionModal/LPVaultTransactionModal.tsx
@@ -21,7 +21,7 @@ export function LPVaultTransactionModal({
 }: {
   modalState: LPVaultTransactionModalState;
 }) {
-  const { user } = useConnectedUser();
+  const { user, isSafe } = useConnectedUser();
 
   const { setModal } = useModal();
 
@@ -37,7 +37,7 @@ export function LPVaultTransactionModal({
         (modalState.transactionType === "LOCK" ? (
           <LockingTransaction user={user} modalState={modalState} />
         ) : (
-          <WithdrawTransaction user={user} modalState={modalState} />
+          <WithdrawTransaction user={user} modalState={modalState} isSafe={isSafe} />
         ))}
     </ModalContainer>
   );

--- a/src/app/core/components/Modal/LPVaultTransactionModal/WithdrawTransaction.tsx
+++ b/src/app/core/components/Modal/LPVaultTransactionModal/WithdrawTransaction.tsx
@@ -1,254 +1,223 @@
-import { formatUnits, Hex } from "viem";
-import {
-  ModalContent,
-  // ModalHeading
-} from "../LPModalUI";
-import {
-  // ModalAdviceText,
-  // ModalContainer,
-  // ModalContent,
-  ModalHeading,
-  // transactionIcons,
-  // TransactionValue,
-} from "../ModalUI";
-import { useEffect, useReducer, useState } from "react";
+import { formatUnits } from "viem";
+import { ModalContent, ModalHeading } from "../LPModalUI";
+import { useState } from "react";
 import { useRefetchOnBlockChangeForUser } from "@/app/core/hooks/useRefetchOnBlockChange";
-import { useWriteContract, useSimulateContract } from "wagmi";
+import { useWriteContract,  useSimulateContract } from "wagmi";
 import { BUTTERED_BREAD_ABI } from "@/abi";
 import { TUserConnected } from "@/app/core/hooks/useConnectedUser";
 import {
-  LPVaultTransactionModalState,
-  useModal,
+	LPVaultTransactionModalState,
+	useModal,
 } from "@/app/core/context/ModalContext";
 import { getChain } from "@/chainConfig";
-import { useIsMobile } from "@/app/core/hooks/useIsMobile";
-
 import { useTransactions } from "@/app/core/context/TransactionsContext/TransactionsContext";
-import { withdrawReducer } from "./withdrawReducer";
 import { UnlockVPRate, ValueText, WXDaiBreadIcon } from "./VPRate";
 import { StatusBadge } from "./Locking/LockingTransaction";
 import { ExternalLink } from "@/app/core/components/ExternalLink";
 import { Body, LiftedButton } from "@breadcoop/ui";
 import {
-  ArrowCounterClockwiseIcon,
-  ArrowUpRightIcon,
+	ArrowCounterClockwiseIcon,
+	ArrowUpRightIcon,
 } from "@phosphor-icons/react/ssr";
+import { TTransactionHash } from "@/app/core/context/TransactionsContext/TransactionsReducer";
+import SafeAppsSDK from "@safe-global/safe-apps-sdk/dist/src/sdk";
+import { TransactionStatus } from "@safe-global/safe-apps-sdk/dist/src/types";
+
+type WithdrawStatus = "idle" | "submitted" | "confirmed" | "reverted";
 
 export function WithdrawTransaction({
-  user,
-  modalState,
+	user,
+	modalState,
+	isSafe
 }: {
-  user: TUserConnected;
-  modalState: LPVaultTransactionModalState;
+	user: TUserConnected;
+	modalState: LPVaultTransactionModalState;
+	isSafe: boolean
 }) {
-  const { transactionsState, transactionsDispatch } = useTransactions();
-  const { setModal } = useModal();
-  const [isWalletOpen, setIsWalletOpen] = useState(false);
-  const isMobile = useIsMobile();
-  const chainConfig = getChain(user.chain.id);
-  const [withdrawState, withdrawDispatch] = useReducer(withdrawReducer, {
-    status: "idle",
-  });
+	const { transactionsState, transactionsDispatch } = useTransactions();
+	const { setModal } = useModal();
+	const [isWalletOpen, setIsWalletOpen] = useState(false);
+	const [txHash, setTxHash] = useState<TTransactionHash | null>(null);
+	const chainConfig = getChain(user.chain.id);
+	const { writeContractAsync } = useWriteContract();
 
-  const handleRetry = () => {
-    // Reset to idle state to allow retry
-    withdrawDispatch({
-      type: "RESET",
-    });
-  };
+	const submittedTx = txHash
+		? transactionsState.submitted.find((t) => t.hash === txHash)
+		: null;
 
-  useEffect(() => {
-    transactionsDispatch({
-      type: "NEW",
-      payload: {
-        data: { type: "LP_VAULT_WITHDRAW", transactionType: "UNLOCK" },
-      },
-    });
-  }, [transactionsDispatch]);
+	const status: WithdrawStatus = !txHash
+		? "idle"
+		: submittedTx?.status === "CONFIRMED"
+		? "confirmed"
+		: submittedTx?.status === "REVERTED"
+		? "reverted"
+		: "submitted";
 
-  const { status: lockedBalanceStatus, data: lockedBalance } =
-    useRefetchOnBlockChangeForUser(
-      user.address,
-      chainConfig.BUTTERED_BREAD.address,
-      BUTTERED_BREAD_ABI,
-      "accountToLPBalance",
-      [user.address, chainConfig.BUTTER.address]
-    );
+	const { status: lockedBalanceStatus, data: lockedBalance } =
+		useRefetchOnBlockChangeForUser(
+			user.address,
+			chainConfig.BUTTERED_BREAD.address,
+			BUTTERED_BREAD_ABI,
+			"accountToLPBalance",
+			[user.address, chainConfig.BUTTER.address],
+		);
 
-  const prepareWrite = useSimulateContract({
-    address: chainConfig.BUTTERED_BREAD.address,
-    abi: BUTTERED_BREAD_ABI,
-    functionName: "withdraw",
-    args: [chainConfig.BUTTER.address, modalState.parsedValue],
-    query: {
-      enabled:
-        lockedBalanceStatus === "success" &&
-        modalState.parsedValue <= (lockedBalance as bigint),
-    },
-    chainId: chainConfig.ID,
-  });
+	const prepareWrite = useSimulateContract({
+		address: chainConfig.BUTTERED_BREAD.address,
+		abi: BUTTERED_BREAD_ABI,
+		functionName: "withdraw",
+		args: [chainConfig.BUTTER.address, modalState.parsedValue],
+		query: {
+			enabled:
+				lockedBalanceStatus === "success" &&
+				modalState.parsedValue <= (lockedBalance as bigint),
+		},
+		chainId: chainConfig.ID,
+	});
 
-  useEffect(() => {
-    if (prepareWrite.status === "error") {
-      console.log(prepareWrite.error);
-    }
-  }, [prepareWrite]);
+	const handleSubmit = async () => {
+		if (!prepareWrite.data) return;
 
-  const {
-    writeContract: contractWriteWrite,
-    status: contractWriteStatus,
-    data: contractWriteData,
-  } = useWriteContract();
+		transactionsDispatch({
+			type: "NEW",
+			payload: {
+				data: { type: "LP_VAULT_WITHDRAW", transactionType: "UNLOCK" },
+			},
+		});
 
-  useEffect(() => {
-    if (contractWriteStatus === "success" && contractWriteData) {
-      transactionsDispatch({
-        type: "SET_SUBMITTED",
-        payload: { hash: contractWriteData },
-      });
-      withdrawDispatch({
-        type: "TRANSACTION_SUBMITTED",
-        payload: { hash: contractWriteData },
-      });
-      setIsWalletOpen(false);
-    }
-    if (contractWriteStatus === "error") {
-      setIsWalletOpen(false);
-    }
-  }, [contractWriteStatus, contractWriteData, transactionsDispatch]);
+		setIsWalletOpen(true);
 
-  useEffect(() => {
-    if (withdrawState.status === "idle") return;
-    const tx = transactionsState.submitted.find((t) => {
-      return t.hash === withdrawState.txHash;
-    });
-    if (!tx || tx.status === "SUBMITTED") return;
-    withdrawDispatch({
-      type:
-        tx.status === "CONFIRMED"
-          ? "TRANSACTION_CONFIRMED"
-          : "TRANSACTION_REVERTED",
-    });
-  }, [transactionsState, withdrawState]);
+		try {
+			const hash = await writeContractAsync(prepareWrite.data.request);
 
-  return (
-    <>
-      <ModalHeading>Unlocking LP Tokens</ModalHeading>
-      <ModalContent className="!gap-2">
-        <StatusBadge
-          variant="unlock"
-          status={
-            withdrawState.status === "confirmed"
-              ? "complete"
-              : withdrawState.status === "reverted"
-              ? "reverted"
-              : "in-progress"
-          }
-        />
-        {withdrawState.status !== "confirmed" && (
-          <>
-            <UnlockVPRate value={modalState.parsedValue} />
-            <div className="border-l-4 border-system-warning shadow-md p-[20px] flex flex-col items-center gap-4">
-              <Body>
-                By unlocking your LP tokens you will not be eligible to receive
-                voting power within the Bread Coop network in future voting
-                cycles.
-              </Body>
-            </div>
-          </>
-        )}
-        {withdrawState.status === "idle" && (
-          <Body className="text-surface-grey">
-            Press ‘Unlock LP tokens’ to execute the transaction
-          </Body>
-        )}
-        {withdrawState.status === "submitted" && (
-          <Body>Awaiting on-chain confirmation...</Body>
-        )}
-        {withdrawState.status === "reverted" && (
-          <Body className="text-status-error">
-            Transaction failed. Please try again.
-          </Body>
-        )}
-        {(() => {
-          if (withdrawState.status === "confirmed")
-            return (
-              <>
-                <UnlockingSuccess
-                  value={modalState.parsedValue}
-                  explorerLink={`${chainConfig.EXPLORER}/tx/${withdrawState.txHash}`}
-                />
-                <div className="w-full">
-                  <LiftedButton
-                    preset="secondary"
-                    onClick={() => {
-                      setModal(null);
-                    }}
-                    disabled={isWalletOpen}
-                    width="full"
-                  >
-                    Return to vault page
-                  </LiftedButton>
-                </div>
-              </>
-            );
-          if (withdrawState.status === "submitted")
-            return (
-              <div className="w-full">
-                <LiftedButton onClick={() => {}} disabled={true} width="full">
-                  Unlocking...
-                </LiftedButton>
-              </div>
-            );
-          if (withdrawState.status === "reverted")
-            return (
-              <div className="w-full">
-                <LiftedButton
-                  onClick={() => {
-                    if (!contractWriteWrite) return;
-                    handleRetry();
-                    setIsWalletOpen(true);
-                    contractWriteWrite(prepareWrite.data!.request);
-                  }}
-                  disabled={isWalletOpen}
-                  width="full"
-                  leftIcon={<ArrowCounterClockwiseIcon size={24} />}
-                >
-                  Try again
-                </LiftedButton>
-              </div>
-            );
-          return (
-            <div className="w-full">
-              <LiftedButton
-                onClick={() => {
-                  if (!contractWriteWrite) return;
-                  setIsWalletOpen(true);
-                  contractWriteWrite(prepareWrite.data!.request);
-                }}
-                disabled={isWalletOpen}
-                width="full"
-              >
-                Unlock LP tokens
-              </LiftedButton>
-            </div>
-          );
-        })()}
-      </ModalContent>
-    </>
-  );
+			if (isSafe) {
+				const safeSdk = new SafeAppsSDK();
+				const tx = await safeSdk.txs.getBySafeTxHash(hash);
+
+				if (tx.txStatus === TransactionStatus.AWAITING_CONFIRMATIONS) {
+					transactionsDispatch({
+						type: "SET_SAFE_SUBMITTED",
+						payload: { hash },
+					});
+					setTxHash(hash);
+					return;
+				}
+			}
+
+			transactionsDispatch({
+				type: "SET_SUBMITTED",
+				payload: { hash },
+			});
+			setTxHash(hash);
+		} catch(e) {
+			console.log("__ ERROR UNLOCKING LP TOKEN __", e);
+		} finally {
+			setIsWalletOpen(false);
+		}
+	};
+
+	const handleRetry = () => {
+		setTxHash(null);
+		handleSubmit();
+	};
+
+	return (
+		<>
+			<ModalHeading>Unlocking LP Tokens</ModalHeading>
+			<ModalContent className="!gap-2">
+				<StatusBadge
+					variant="unlock"
+					status={
+						status === "confirmed"
+							? "complete"
+							: status === "reverted"
+							? "reverted"
+							: "in-progress"
+					}
+				/>
+				{status !== "confirmed" && (
+					<>
+						<UnlockVPRate value={modalState.parsedValue} />
+						<div className="border-l-4 border-system-warning shadow-md p-[20px] flex flex-col items-center gap-4">
+							<Body>
+								By unlocking your LP tokens you will not be
+								eligible to receive voting power within the
+								Bread Coop network in future voting cycles.
+							</Body>
+						</div>
+					</>
+				)}
+				{status === "idle" && (
+					<Body className="text-surface-grey">
+						Press `Unlock LP tokens` to execute the transaction
+					</Body>
+				)}
+				{status === "submitted" && (
+					<Body>Awaiting on-chain confirmation...</Body>
+				)}
+				{status === "reverted" && (
+					<Body className="text-status-error">
+						Transaction failed. Please try again.
+					</Body>
+				)}
+
+				<div className="w-full">
+					{status === "confirmed" && txHash && (
+						<>
+							<UnlockingSuccess
+								value={modalState.parsedValue}
+								explorerLink={`${chainConfig.EXPLORER}/tx/${txHash}`}
+							/>
+							<LiftedButton
+								preset="secondary"
+								onClick={() => setModal(null)}
+								disabled={isWalletOpen}
+								width="full"
+							>
+								Return to vault page
+							</LiftedButton>
+						</>
+					)}
+					{status === "submitted" && (
+						<LiftedButton disabled width="full">
+							Unlocking...
+						</LiftedButton>
+					)}
+					{status === "reverted" && (
+						<LiftedButton
+							onClick={handleRetry}
+							disabled={isWalletOpen}
+							width="full"
+							leftIcon={<ArrowCounterClockwiseIcon size={24} />}
+						>
+							Try again
+						</LiftedButton>
+					)}
+					{status === "idle" && (
+						<LiftedButton
+							onClick={handleSubmit}
+							disabled={isWalletOpen}
+							width="full"
+						>
+							Unlock LP tokens
+						</LiftedButton>
+					)}
+				</div>
+			</ModalContent>
+		</>
+	);
 }
 
 function UnlockingSuccess({
-  value,
-  explorerLink,
+	value,
+	explorerLink,
 }: {
-  value: bigint;
-  explorerLink: string;
+	value: bigint;
+	explorerLink: string;
 }) {
-  const tokenAmount = formatUnits(value, 18);
+	const tokenAmount = formatUnits(value, 18);
 
-  return (
+	return (
 		<div className="w-full p-6 pb-0 flex flex-col items-center gap-4">
 			<div className="w-auto border border-surface-ink flex items-center gap-2 px-2 mx-auto bg-paper-main">
 				<WXDaiBreadIcon />

--- a/src/app/core/context/TransactionsContext/SafeTransactionWatcher.tsx
+++ b/src/app/core/context/TransactionsContext/SafeTransactionWatcher.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from "react";
+import SafeAppsSDK, { TransactionStatus } from "@safe-global/safe-apps-sdk";
+import {
+  TSafeTransactionSubmitted,
+  TTransactionsDispatch,
+} from "./TransactionsReducer";
+import { useToast } from "../ToastContext/ToastContext";
+
+const POLL_INTERVAL_MS = 3000;
+
+/**
+ * Watches a Safe Wallet transaction by polling getBySafeTxHash every
+ * POLL_INTERVAL_MS milliseconds. Safe transactions don't resolve
+ * synchronously — they require multi-sig confirmation and return a
+ * safeTxHash instead of a regular on-chain txHash. Without this
+ * watcher, SAFE_SUBMITTED transactions get stuck "in process" forever.
+ */
+export function SafeTransactionWatcher({
+  transaction,
+  transactionsDispatch,
+}: {
+  transaction: TSafeTransactionSubmitted;
+  transactionsDispatch: TTransactionsDispatch;
+}) {
+  const { hash } = transaction;
+  const { toastDispatch } = useToast();
+  const sdkRef = useRef(new SafeAppsSDK());
+
+  useEffect(() => {
+    toastDispatch({
+      type: "NEW",
+      payload: { toastType: "SUBMITTED", txHash: hash },
+    });
+  }, [hash, toastDispatch]);
+
+  useEffect(() => {
+    const sdk = sdkRef.current;
+    let intervalId: ReturnType<typeof setInterval>;
+
+    const poll = async () => {
+      try {
+        const tx = await sdk.txs.getBySafeTxHash(hash as string);
+
+        if (tx.txStatus === TransactionStatus.SUCCESS) {
+          transactionsDispatch({
+            type: "SET_SUCCESS",
+            payload: { hash: hash as string },
+          });
+          clearInterval(intervalId);
+        } else if (
+          tx.txStatus === TransactionStatus.CANCELLED ||
+          tx.txStatus === TransactionStatus.FAILED
+        ) {
+          transactionsDispatch({
+            type: "SET_REVERTED",
+            payload: { hash: hash as string },
+          });
+          toastDispatch({
+            type: "NEW",
+            payload: { toastType: "REVERTED", txHash: hash as string },
+          });
+          clearInterval(intervalId);
+        }
+        // AWAITING_CONFIRMATIONS and AWAITING_EXECUTION are non-terminal;
+        // keep polling.
+      } catch {
+        // SDK call failed — tx may not be indexed yet; keep polling.
+      }
+    };
+
+    poll();
+    intervalId = setInterval(poll, POLL_INTERVAL_MS);
+
+    return () => clearInterval(intervalId);
+  }, [hash, transactionsDispatch, toastDispatch]);
+
+  return null;
+}

--- a/src/app/core/context/TransactionsContext/SafeTransactionWatcher.tsx
+++ b/src/app/core/context/TransactionsContext/SafeTransactionWatcher.tsx
@@ -23,15 +23,16 @@ export function SafeTransactionWatcher({
   transactionsDispatch: TTransactionsDispatch;
 }) {
   const { hash } = transaction;
+  const typedHash = hash as `0x${string}`;
   const { toastDispatch } = useToast();
   const sdkRef = useRef(new SafeAppsSDK());
 
   useEffect(() => {
     toastDispatch({
       type: "NEW",
-      payload: { toastType: "SUBMITTED", txHash: hash },
+      payload: { toastType: "SUBMITTED", txHash: typedHash },
     });
-  }, [hash, toastDispatch]);
+  }, [typedHash, toastDispatch]);
 
   useEffect(() => {
     const sdk = sdkRef.current;
@@ -39,12 +40,12 @@ export function SafeTransactionWatcher({
 
     const poll = async () => {
       try {
-        const tx = await sdk.txs.getBySafeTxHash(hash as string);
+        const tx = await sdk.txs.getBySafeTxHash(typedHash);
 
         if (tx.txStatus === TransactionStatus.SUCCESS) {
           transactionsDispatch({
             type: "SET_SUCCESS",
-            payload: { hash: hash as string },
+            payload: { hash: typedHash },
           });
           clearInterval(intervalId);
         } else if (
@@ -53,11 +54,11 @@ export function SafeTransactionWatcher({
         ) {
           transactionsDispatch({
             type: "SET_REVERTED",
-            payload: { hash: hash as string },
+            payload: { hash: typedHash },
           });
           toastDispatch({
             type: "NEW",
-            payload: { toastType: "REVERTED", txHash: hash as string },
+            payload: { toastType: "REVERTED", txHash: typedHash },
           });
           clearInterval(intervalId);
         }
@@ -72,7 +73,7 @@ export function SafeTransactionWatcher({
     intervalId = setInterval(poll, POLL_INTERVAL_MS);
 
     return () => clearInterval(intervalId);
-  }, [hash, transactionsDispatch, toastDispatch]);
+  }, [typedHash, transactionsDispatch, toastDispatch]);
 
   return null;
 }

--- a/src/app/core/context/TransactionsContext/TransactionsContext.tsx
+++ b/src/app/core/context/TransactionsContext/TransactionsContext.tsx
@@ -11,6 +11,7 @@ import {
   TransactionsReducer,
 } from "./TransactionsReducer";
 import { TransactionWatcher } from "./TransactionsWatcher";
+import { SafeTransactionWatcher } from "./SafeTransactionWatcher";
 
 const TransactionsContext = createContext<
   | {
@@ -33,15 +34,27 @@ function TransactionsProvider({ children }: { children: ReactNode }) {
 
   return (
     <TransactionsContext.Provider value={value}>
-      {value.transactionsState.submitted.map((transaction) =>
-        transaction.status === "SUBMITTED" ? (
-          <TransactionWatcher
-            key={`watching_transaction_${transaction.hash}`}
-            transaction={transaction}
-            transactionsDispatch={value.transactionsDispatch}
-          />
-        ) : null
-      )}
+      {value.transactionsState.submitted.map((transaction) => {
+        if (transaction.status === "SUBMITTED") {
+          return (
+            <TransactionWatcher
+              key={`watching_transaction_${transaction.hash}`}
+              transaction={transaction}
+              transactionsDispatch={value.transactionsDispatch}
+            />
+          );
+        }
+        if (transaction.status === "SAFE_SUBMITTED") {
+          return (
+            <SafeTransactionWatcher
+              key={`watching_safe_transaction_${transaction.hash}`}
+              transaction={transaction}
+              transactionsDispatch={value.transactionsDispatch}
+            />
+          );
+        }
+        return null;
+      })}
       {children}
     </TransactionsContext.Provider>
   );

--- a/src/app/governance/lp-vaults/components/VaultPanel.tsx
+++ b/src/app/governance/lp-vaults/components/VaultPanel.tsx
@@ -8,35 +8,37 @@ import {
 } from "@radix-ui/react-accordion";
 
 import useDebounce from "@/app/bakery/hooks/useDebounce";
-import Button from "@/app/core/components/Button";
+// import Button from "@/app/core/components/Button";
 import { useModal } from "@/app/core/context/ModalContext";
 import { Logo, Body, LiftedButton, Caption } from "@breadcoop/ui";
 import { useConnectedUser } from "@/app/core/hooks/useConnectedUser";
 import { SelectTransaction } from "./SelectTransaction";
 import { sanitizeInputValue } from "@/app/core/util/sanitizeInput";
-import { WXDAIIcon } from "@/app/core/components/Icons/TokenIcons";
+// import { WXDAIIcon } from "@/app/core/components/Icons/TokenIcons";
 import { ExternalLink } from "@/app/core/components/ExternalLink";
-import { LinkIcon } from "@/app/core/components/Icons/LinkIcon";
+// import { LinkIcon } from "@/app/core/components/Icons/LinkIcon";
 import { useTokenBalances } from "@/app/core/context/TokenBalanceContext/TokenBalanceContext";
 import { lpTokenMeta } from "@/app/lpTokenMeta";
 import { MaxButton } from "@/app/core/components/MaxButton";
 import { useTransactions } from "@/app/core/context/TransactionsContext/TransactionsContext";
 import { formatBalance } from "@/app/core/util/formatter";
 import { useVaultTokenBalance } from "../context/VaultTokenBalanceContext";
-import { AccountMenu } from "@/app/core/components/Header/AccountMenu";
-import { useChainModal } from "@rainbow-me/rainbowkit";
+// import { AccountMenu } from "@/app/core/components/Header/AccountMenu";
+// import { useChainModal } from "@rainbow-me/rainbowkit";
 import { ArrowUpRightIcon, CaretDownIcon } from "@phosphor-icons/react/ssr";
 import { LoginButton } from "@/app/components/login-button";
+import { useActiveChain } from "@/app/core/hooks/useActiveChain";
 
 export type TransactionType = "LOCK" | "UNLOCK";
 
 export function VaultPanel({ tokenAddress }: { tokenAddress: Hex }) {
-  const { openChainModal } = useChainModal();
+  // const { openChainModal } = useChainModal();
   const [inputValue, setInputValue] = useState("");
   const [transactionType, setTransactionType] =
     useState<TransactionType>("LOCK");
   const { user } = useConnectedUser();
   const { transactionsState } = useTransactions();
+  const activeChain = useActiveChain();
 
   const { BUTTER: lpTokenBalance } = useTokenBalances();
   const vaultTokenBalance = useVaultTokenBalance();
@@ -56,7 +58,20 @@ export function VaultPanel({ tokenAddress }: { tokenAddress: Hex }) {
 
   const { setModal } = useModal();
 
+  const disableBtn =
+		(transactionType === "LOCK" && !(Number(inputValue) > 0)) ||
+		(transactionType === "LOCK" &&
+			lpTokenBalance?.status === "SUCCESS" &&
+			!(Number(inputValue) <= Number(lpTokenBalance.value))) ||
+		(transactionType === "UNLOCK" &&
+			vaultTokenBalance?.butter.status === "success" &&
+			!(Number(vaultTokenBalance?.butter.value) > 0));
+
   function submitTransaction() {
+    console.log({ disableBtn });
+
+    if (disableBtn) return;
+
     if (transactionType === "LOCK") {
       setModal({
         type: "LP_VAULT_TRANSACTION",
@@ -65,15 +80,20 @@ export function VaultPanel({ tokenAddress }: { tokenAddress: Hex }) {
       });
       return;
     }
+
     if (vaultTokenBalance?.butter.status !== "success") {
       return;
     }
+
     setModal({
       type: "LP_VAULT_TRANSACTION",
       transactionType: "UNLOCK",
       parsedValue: vaultTokenBalance.butter.value,
     });
   }
+
+  console.log("__ VALUT TOKEN BALANCE __", vaultTokenBalance);
+  console.log("--- ACTIVE CHAIN ---", activeChain);
 
   return (
     <AccordionItem
@@ -141,8 +161,6 @@ export function VaultPanel({ tokenAddress }: { tokenAddress: Hex }) {
           </div>
         </AccordionTrigger>
       </AccordionHeader>
-      {/* <AccordionContent className="pt-2 pb-4 md:px-20"> */}
-      {/* <AccordionContent className="pt-2 md:px-20"> */}
       <AccordionContent className="mt-8 md:px-[4.40625rem]">
         <div className="grid grid-cols-2 gap-5 px-5">
           <section className="col-span-2 lg:col-span-1 flex flex-col gap-4">
@@ -309,15 +327,7 @@ export function VaultPanel({ tokenAddress }: { tokenAddress: Hex }) {
                     submitTransaction();
                   }}
                   width="full"
-                  disabled={
-                    (transactionType === "LOCK" && !(Number(inputValue) > 0)) ||
-                    (transactionType === "LOCK" &&
-                      lpTokenBalance?.status === "SUCCESS" &&
-                      !(Number(inputValue) <= Number(lpTokenBalance.value))) ||
-                    (transactionType === "UNLOCK" &&
-                      vaultTokenBalance?.butter.status === "success" &&
-                      !(Number(vaultTokenBalance?.butter.value) > 0))
-                  }
+                  disabled={disableBtn}
                 >
                   {transactionType === "UNLOCK" ? "Unlock" : "Lock"} LP Tokens
                 </LiftedButton>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,10 +24,15 @@ export default function Home() {
 			<BalanceBanner />
 			<div className={clsx(WRAPPER_CLASSES, "")}>
 				<div className="md:grid md:grid-cols-2 md:gap-x-6 lg:gap-x-[9.5rem]">
-					<Heading1 className="text-[2.5rem] text-primary-orange mb-4 md:max-w-[32rem] md:flex md:flex-col md:leading-[0.9] md:text-[3.5rem] lg:text-[4rem]">
-						<span>THE</span> <span>SOLIDARITY</span>{" "}
-						<span>FUND</span>
-					</Heading1>
+					<div>
+						<Heading1 className="text-[2.5rem] text-primary-orange mb-4 md:max-w-[32rem] md:flex md:flex-col md:leading-[0.9] md:text-[3.5rem] lg:text-[4rem]">
+							<span>THE</span> <span>SOLIDARITY</span>{" "}
+							<span>FUND</span>
+						</Heading1>
+						<Body className="font-breadDisplay text-surface-grey-2 mb-4 md:mb-6">
+							give without giving.
+						</Body>
+					</div>
 					<div className="row-span-2 md:w-full md:max-w-[451px]">
 						<Suspense>
 							<SwapWrapper />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,52 +1,29 @@
 // "use client";
-import { Suspense } from "react";
 import { type Metadata } from "next";
 
 import { AppTitle } from "./bakery/components/AppTitle";
 import FAQWrapper from "./components/FAQWrapper";
-import SwapWrapper from "./components/SwapWrapper";
-import { Body, Heading1, Heading2, LiftedButton } from "@breadcoop/ui";
-import { Apy } from "./bakery/components/Apy";
-import { BreadCirculation } from "./bakery/components/BreadCirculation";
+import { Body, Heading2 } from "@breadcoop/ui";
 import clsx from "clsx";
 import { WRAPPER_CLASSES } from "./core/util/classes";
-import { Interest } from "./bakery/components/Interest";
 import { ProjectBackers } from "./bakery/components/Backers";
 import { MonthlyVoters } from "./bakery/components/MonthlyVoters";
 import { ViewAnalytics } from "./bakery/components/Analytics";
 import Actions from "./bakery/components/Actions";
 import { generateMetadata } from "@/lib/site-metadata";
 import { BalanceBanner } from "./bakery/components/Banners/BalanceBanner";
+import { SolidarityHero } from "./bakery/components/SolidarityHero";
 
 export default function Home() {
 	return (
 		<>
 			<BalanceBanner />
 			<div className={clsx(WRAPPER_CLASSES, "")}>
-				<div className="md:grid md:grid-cols-2 md:gap-x-6 lg:gap-x-[9.5rem]">
-					<div>
-						<Heading1 className="text-[2.5rem] text-primary-orange mb-4 md:max-w-[32rem] md:flex md:flex-col md:leading-[0.9] md:text-[3.5rem] lg:text-[4rem]">
-							<span>THE</span> <span>SOLIDARITY</span>{" "}
-							<span>FUND</span>
-						</Heading1>
-						<Body className="font-breadDisplay text-surface-grey-2 mb-4 md:mb-6">
-							give without giving.
-						</Body>
-					</div>
-					<div className="row-span-2 md:w-full md:max-w-[451px]">
-						<Suspense>
-							<SwapWrapper />
-						</Suspense>
-					</div>
-					<div className="md:max-w-[32rem]">
-						<Interest />
-						<div className="md:flex md:items-center md:justify-start md:gap-4 md:flex-wrap lg:flex-nowrap">
-							<BreadCirculation />
-							<Apy />
-						</div>
-					</div>
-				</div>
-				<div className="mt-12 md:flex md:items-start md:justify-between md:gap-8">
+				<SolidarityHero />
+				<div
+					id="how-it-works"
+					className="scroll-mt-24 mt-12 md:flex md:items-start md:justify-between md:gap-8"
+				>
 					<figure className="w-[23.82rem] h-[16rem] ml-auto bg-orange-0 overflow-hidden relative right-[-1rem] mb-8 md:w-[33.125rem] md:h-[22.25rem] md:order-2 md:right-[-1.5rem] md:static md:mt-8 md:grow-0">
 						<img
 							src="/bake_hand_mobile.png"

--- a/src/lib/peer.ts
+++ b/src/lib/peer.ts
@@ -1,6 +1,6 @@
 export const peerConfig = {
   baseUrl: "https://peer.xyz/swap",
-  referrer: "Bread Crowdstaking",
+  referrer: "Bread Solidarity Fund",
   referrerLogo: "https://fund.bread.coop/logo.svg",
   // xDAI on Gnosis Chain (chainId: 100, native token)
   toToken: "100:0x0000000000000000000000000000000000000000",

--- a/src/lib/site-metadata.ts
+++ b/src/lib/site-metadata.ts
@@ -14,15 +14,16 @@ type MetadataConfig = {
 };
 
 const DEFAULT_METADATA = {
-  title: "Bread Crowdstaking",
-  description: "Bake and burn BREAD. Fund post-capitalist web3.",
+  title: "Bread Solidarity Fund",
+  description:
+    "The Bread Solidarity Fund pools stablecoin yield to democratically fund post-capitalist web3 projects.",
   url: "https://fund.bread.coop/",
-  siteName: "Bread Crowdstaking",
+  siteName: "Bread Solidarity Fund",
   image: {
     url: "https://bread.coop/preview.png?v=33",
     width: 2048,
     height: 1536,
-    alt: "Bread Crowdstaking",
+    alt: "Bread Solidarity Fund",
   },
 } as const;
 


### PR DESCRIPTION
## Summary

A reworked **Solidarity Fund landing hero** that surfaces the fund's data **as visuals instead of walls of text/numbers** — exploring the onboarding/clarity direction from #394 and building on the mockup in that thread.

**This is a showcase for team review** — opening it so we can preview on Netlify and discuss before refining.

## What changed

- New `src/app/bakery/components/SolidarityHero.tsx`, swapped into the top of the bake/burn page (`src/app/page.tsx`).
- **Left column** — slogan-forward: `THE SOLIDARITY FUND` + "Give without giving…" + two CTAs:
  - **Support fund** → opens the bake module in a modal (reuses `SwapWrapper` + `useModal`)
  - **How it works →** → smooth-scrolls to the "We decide, together." explainer
- **Right column — data as pictures:**
  - **Backers** → an avatar cluster (deterministic identicons) + live count, instead of a number in a chip
  - **Projects** → colored tiles for the member projects (Labor DAO, Crypto Commons, Symbiota, Breadchain…) + a "more" tile
  - **APY** → a small donut **ring** with the rate
  - **Total funding** → a quiet `$BREAD` accent, no longer the giant hero number

## Data

All metrics keep their existing sources (`useVaultAPY`, `/api/bread-backers`, `/api/total-bread-distributed`, `memberProjects`) and fall back to the same constants the old widgets used, so the hero renders even when an endpoint/RPC is unavailable.

## Review notes

- Best viewed on the deploy preview (needs the app's env to boot locally).
- The "20 projects" from the mock is shown as the real member-project tiles + a "more" tile; happy to wire a live funded-projects count if we have a source.
- Open questions for the team: keep inline baking too, or is "Support fund → modal" the right call? Avatar style (identicons vs. illustrated)? Ring vs. sparkline for APY?

Relates to #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)