### PR TITLE
feat: Safe wallet transaction module for Solidarity Fund (#279)

### DIFF
--- a/src/app/bakery/components/Swap/Bake.tsx
+++ b/src/app/bakery/components/Swap/Bake.tsx
@@ -83,7 +83,10 @@ export default function Bake({
 						type: "SET_SAFE_SUBMITTED",
 						payload: { hash },
 					});
-					setModal({ type: "BAKERY_TRANSACTION", hash });
+					// Safe transactions need multi-sig approval inside the
+					// Safe app, so route to the dedicated Safe-aware modal
+					// that guides the user through the confirmation flow.
+					setModal({ type: "SAFE_TRANSACTION", hash });
 					clearInputValue();
 
 					return;

--- a/src/app/core/components/Header/DesktopNavigation.tsx
+++ b/src/app/core/components/Header/DesktopNavigation.tsx
@@ -2,9 +2,10 @@ import { useConnectedUser } from "../../hooks/useConnectedUser";
 import { LoginButton } from "@/app/components/login-button";
 import NavAccountMenu from "@/app/components/nav/account-menu";
 import PageMenuLink from "./page-menu-link";
+import { SafeIndicatorBadge } from "./SafeIndicatorBadge";
 
 function DesktopNavigation({ currentPath }: { currentPath: string }) {
-	const { user } = useConnectedUser();
+	const { user, isSafe } = useConnectedUser();
 	return (
 		<div className="hidden md:flex md:flex-grow md:items-center md:gap-8 md:ml-auto md:max-w-max">
 			<nav
@@ -43,6 +44,7 @@ function DesktopNavigation({ currentPath }: { currentPath: string }) {
         Docs <span className="ml-2"></span><LinkIcon />
       </DesktopNavigationLink> */}
 			</nav>
+			{isSafe && user.status === "CONNECTED" && <SafeIndicatorBadge />}
 			{user.status === "CONNECTED" ? (
 				<NavAccountMenu />
 			) : (

--- a/src/app/core/components/Header/SafeIndicatorBadge.tsx
+++ b/src/app/core/components/Header/SafeIndicatorBadge.tsx
@@ -1,0 +1,23 @@
+import { ShieldCheckIcon } from "@phosphor-icons/react";
+import clsx from "clsx";
+
+/**
+ * Persistent indicator shown in the navigation while a Gnosis Safe wallet is
+ * connected. Signals to the user that transactions will require multi-sig
+ * confirmation inside the Safe app rather than a standard wallet popup.
+ */
+export function SafeIndicatorBadge({ className }: { className?: string }) {
+	return (
+		<div
+			className={clsx(
+				"flex items-center gap-1.5 px-2 py-1 border border-primary-jade",
+				"text-primary-jade font-bold text-sm bg-primary-jade/5 whitespace-nowrap",
+				className
+			)}
+			title="A Gnosis Safe wallet is connected. Transactions are confirmed in the Safe app."
+		>
+			<ShieldCheckIcon size={16} color="#286B63" weight="bold" />
+			<span>Safe</span>
+		</div>
+	);
+}

--- a/src/app/core/components/Modal/ConfirmBurnModal.tsx
+++ b/src/app/core/components/Modal/ConfirmBurnModal.tsx
@@ -46,9 +46,9 @@ export function ConfirmBurnModal({
 						type: "SET_SAFE_SUBMITTED",
 						payload: { hash },
 					});
-					setModal({ type: "BAKERY_TRANSACTION", hash });
-					console.log("__ TD 2 __", { hash });
-					console.log("__ SM 2", hash);
+					// Safe transactions require multi-sig approval inside the
+					// Safe app — route to the dedicated Safe transaction modal.
+					setModal({ type: "SAFE_TRANSACTION", hash });
 					modalState.clearInputValue?.();
 					return;
 				}

--- a/src/app/core/components/Modal/LPModalUI.tsx
+++ b/src/app/core/components/Modal/LPModalUI.tsx
@@ -151,5 +151,6 @@ export const transactionIcons: {
   SUBMITTED: <TransactionStatusSpinner />,
   CONFIRMED: <TransactionStatusCheck />,
   SAFE_SUBMITTED: <TransactionStatusCheck />,
+  SAFE_EXPIRED: <TransactionStatusCross />,
   REVERTED: <TransactionStatusCross />,
 };

--- a/src/app/core/components/Modal/ModalPresenter.tsx
+++ b/src/app/core/components/Modal/ModalPresenter.tsx
@@ -7,6 +7,7 @@ import { ConfirmBurnModal } from "./ConfirmBurnModal";
 import { ModalOverlay } from "./ModalUI";
 import { VoteTransactionModal } from "./TransactionModal/VoteTransactionModal";
 import { BakeryTransactionModal } from "./TransactionModal/BakeryTransactionModal";
+import { SafeTransactionModal } from "./TransactionModal/SafeTransactionModal";
 import { LPVaultTransactionModal } from "./LPVaultTransactionModal/LPVaultTransactionModal";
 import { GenericModal } from "./GenericModal";
 import { LiFiBridgeModal } from "./Bridge/LiFiModal";
@@ -28,6 +29,8 @@ export function ModalPresenter() {
                   switch (modalState.type) {
                     case "BAKERY_TRANSACTION":
                       return <BakeryTransactionModal modalState={modalState} />;
+                    case "SAFE_TRANSACTION":
+                      return <SafeTransactionModal modalState={modalState} />;
                     case "VOTE_TRANSACTION":
                       return <VoteTransactionModal modalState={modalState} />;
                     case "CONFIRM_BURN":

--- a/src/app/core/components/Modal/ModalUI.tsx
+++ b/src/app/core/components/Modal/ModalUI.tsx
@@ -238,5 +238,6 @@ export const transactionIcons: {
   SUBMITTED: <TransactionStatusSpinner />,
   CONFIRMED: <TransactionStatusCheck />,
   SAFE_SUBMITTED: <TransactionStatusCheck />,
+  SAFE_EXPIRED: <TransactionStatusCross />,
   REVERTED: <TransactionStatusCross />,
 };

--- a/src/app/core/components/Modal/TransactionModal/BakeryTransactionModal.tsx
+++ b/src/app/core/components/Modal/TransactionModal/BakeryTransactionModal.tsx
@@ -65,6 +65,7 @@ function modalAdviceText(
 		PREPARED: "Please confirm transaction in your wallet",
 		SUBMITTED: "Waiting for on-chain confimation",
 		SAFE_SUBMITTED: "Safe Transaction Submitted",
+		SAFE_EXPIRED: "Safe Transaction Expired",
 		// CONFIRMED:
 		// 	modalType === "BAKE"
 		// 		? "You successfully baked"

--- a/src/app/core/components/Modal/TransactionModal/SafeTransactionModal.tsx
+++ b/src/app/core/components/Modal/TransactionModal/SafeTransactionModal.tsx
@@ -1,0 +1,301 @@
+import { useMemo } from "react";
+import { Close as DialogPrimitiveClose } from "@radix-ui/react-dialog";
+import { Body, Caption, LiftedButton } from "@breadcoop/ui";
+import {
+	ShieldCheckIcon,
+	ClockIcon,
+	CheckCircleIcon,
+	XCircleIcon,
+	WarningCircleIcon,
+	ArrowSquareOutIcon,
+} from "@phosphor-icons/react";
+import clsx from "clsx";
+
+import {
+	ModalContainer,
+	ModalContent,
+	ModalHeading,
+} from "../ModalUI";
+import { useTransactions } from "@/app/core/context/TransactionsContext/TransactionsContext";
+import { SafeTransactionModalState } from "@/app/core/context/ModalContext";
+import { useConnectedUser } from "@/app/core/hooks/useConnectedUser";
+
+const SAFE_APP_BASE = "https://app.safe.global/transactions/queue";
+
+/**
+ * Builds a deep link to the connected Safe's transaction queue so the user
+ * can review and sign the pending transaction. Gnosis Chain uses the `gno:`
+ * address prefix in the Safe web app.
+ */
+function buildSafeAppUrl(safeAddress: string | undefined): string {
+	if (!safeAddress) return "https://app.safe.global";
+	return `${SAFE_APP_BASE}?safe=gno:${safeAddress}`;
+}
+
+type SafeView = "PENDING" | "WAITING" | "CONFIRMED" | "REJECTED" | "EXPIRED";
+
+export function SafeTransactionModal({
+	modalState,
+}: {
+	modalState: SafeTransactionModalState;
+}) {
+	const { transactionsState } = useTransactions();
+	const { user } = useConnectedUser();
+
+	const safeAddress = user.status === "CONNECTED" ? user.address : undefined;
+
+	const transaction = transactionsState.submitted.find(
+		(tx) => tx.hash === modalState.hash
+	);
+
+	const confirmationsSubmitted =
+		transaction?.status === "SAFE_SUBMITTED"
+			? transaction.confirmationsSubmitted ?? 0
+			: 0;
+	const confirmationsRequired =
+		transaction?.status === "SAFE_SUBMITTED"
+			? transaction.confirmationsRequired ?? 0
+			: 0;
+
+	const view: SafeView = useMemo(() => {
+		if (!transaction) return "PENDING";
+		switch (transaction.status) {
+			case "CONFIRMED":
+				return "CONFIRMED";
+			case "REVERTED":
+				return "REJECTED";
+			case "SAFE_EXPIRED":
+				return "EXPIRED";
+			case "SAFE_SUBMITTED":
+				// Once at least one owner has signed (but threshold not yet
+				// reached) we show the signer-progress view.
+				return confirmationsSubmitted > 0 ? "WAITING" : "PENDING";
+			default:
+				return "PENDING";
+		}
+	}, [transaction, confirmationsSubmitted]);
+
+	const safeAppUrl = buildSafeAppUrl(safeAddress);
+
+	const content = SAFE_VIEW_CONTENT[view];
+
+	return (
+		<ModalContainer>
+			<ModalHeading>{content.title}</ModalHeading>
+			<ModalContent>
+				<SafeStatusIcon view={view} />
+
+				{view === "WAITING" && (
+					<SignerProgress
+						submitted={confirmationsSubmitted}
+						required={confirmationsRequired}
+					/>
+				)}
+
+				<Body className="text-surface-grey text-center pt-1 pb-1">
+					{content.body}
+				</Body>
+
+				<SafeStatusNote view={view} />
+
+				<div className="w-full flex flex-col gap-2 mt-2">
+					{(view === "PENDING" || view === "WAITING") && (
+						<div className="lifted-button-container w-full">
+							<LiftedButton
+								width="full"
+								rightIcon={<ArrowSquareOutIcon weight="bold" />}
+								onClick={() =>
+									window.open(safeAppUrl, "_blank")
+								}
+							>
+								Open Safe App
+							</LiftedButton>
+						</div>
+					)}
+
+					{view === "CONFIRMED" && (
+						<DialogPrimitiveClose asChild>
+							<div className="lifted-button-container w-full">
+								<LiftedButton width="full" preset="positive">
+									Done
+								</LiftedButton>
+							</div>
+						</DialogPrimitiveClose>
+					)}
+
+					{(view === "REJECTED" || view === "EXPIRED") && (
+						<DialogPrimitiveClose asChild>
+							<div className="lifted-button-container w-full">
+								<LiftedButton width="full">
+									{view === "REJECTED"
+										? "Try Again"
+										: "Submit Again"}
+								</LiftedButton>
+							</div>
+						</DialogPrimitiveClose>
+					)}
+
+					<DialogPrimitiveClose asChild>
+						<div className="lifted-button-container w-full">
+							<LiftedButton width="full" preset="secondary">
+								{view === "CONFIRMED" ? "Close" : "Cancel"}
+							</LiftedButton>
+						</div>
+					</DialogPrimitiveClose>
+				</div>
+			</ModalContent>
+		</ModalContainer>
+	);
+}
+
+const SAFE_VIEW_CONTENT: Record<
+	SafeView,
+	{ title: string; body: string }
+> = {
+	PENDING: {
+		title: "Safe Transaction Submitted",
+		body: "This transaction needs confirmation in your Safe app — it won't execute until the required number of owners sign it.",
+	},
+	WAITING: {
+		title: "Waiting for Confirmations",
+		body: "Share the Safe link with the other owners to collect the remaining signatures.",
+	},
+	CONFIRMED: {
+		title: "Transaction Confirmed",
+		body: "All required owners signed. Your transaction is now on-chain.",
+	},
+	REJECTED: {
+		title: "Transaction Rejected",
+		body: "This transaction was rejected by the Safe owners. You can submit a new transaction if needed.",
+	},
+	EXPIRED: {
+		title: "Transaction Expired",
+		body: "This transaction was not signed in time. Please submit it again to proceed.",
+	},
+};
+
+function SafeStatusIcon({ view }: { view: SafeView }) {
+	const ICON_SIZE = 40;
+
+	const config: Record<
+		SafeView,
+		{ icon: JSX.Element; bg: string }
+	> = {
+		PENDING: {
+			icon: (
+				<ShieldCheckIcon
+					size={ICON_SIZE}
+					color="var(--color-primary-orange, #EA5817)"
+				/>
+			),
+			bg: "bg-[#EA5817]/10",
+		},
+		WAITING: {
+			icon: (
+				<ClockIcon
+					size={ICON_SIZE}
+					color="var(--color-primary-orange, #EA5817)"
+				/>
+			),
+			bg: "bg-[#EA5817]/10",
+		},
+		CONFIRMED: {
+			icon: <CheckCircleIcon size={ICON_SIZE} color="#32A800" />,
+			bg: "bg-system-green/10",
+		},
+		REJECTED: {
+			icon: <XCircleIcon size={ICON_SIZE} color="#DF0B00" />,
+			bg: "bg-system-red/10",
+		},
+		EXPIRED: {
+			icon: <ClockIcon size={ICON_SIZE} color="#808080" />,
+			bg: "bg-surface-grey/10",
+		},
+	};
+
+	return (
+		<div
+			className={clsx(
+				"size-[72px] rounded-full flex items-center justify-center my-2",
+				config[view].bg
+			)}
+		>
+			{config[view].icon}
+		</div>
+	);
+}
+
+function SignerProgress({
+	submitted,
+	required,
+}: {
+	submitted: number;
+	required: number;
+}) {
+	const safeRequired = required > 0 ? required : 1;
+	const pct = Math.min(100, Math.round((submitted / safeRequired) * 100));
+
+	return (
+		<div className="w-full flex flex-col items-center gap-2 bg-paper-1 rounded-lg p-3">
+			<Body bold className="text-surface-ink text-center">
+				{submitted} of {required || "?"} confirmations received
+			</Body>
+			<div className="w-full h-2 rounded-full bg-paper-main overflow-hidden">
+				<div
+					className="h-full rounded-full bg-primary-orange transition-all"
+					style={{ width: `${pct}%` }}
+				/>
+			</div>
+		</div>
+	);
+}
+
+function SafeStatusNote({ view }: { view: SafeView }) {
+	const notes: Partial<
+		Record<
+			SafeView,
+			{ icon: JSX.Element; text: string; className: string }
+		>
+	> = {
+		PENDING: {
+			icon: <WarningCircleIcon size={16} color="#CE7F00" />,
+			text: "Keep this page open. Your transaction is pending in Safe.",
+			className: "bg-system-warning/10 text-system-warning",
+		},
+		WAITING: {
+			icon: <WarningCircleIcon size={16} color="#CE7F00" />,
+			text: "Waiting for additional owner signatures. Keep this page open.",
+			className: "bg-system-warning/10 text-system-warning",
+		},
+		CONFIRMED: {
+			icon: <CheckCircleIcon size={16} color="#32A800" />,
+			text: "Transaction executed successfully on Gnosis Chain.",
+			className: "bg-system-green/10 text-system-green",
+		},
+		REJECTED: {
+			icon: <XCircleIcon size={16} color="#DF0B00" />,
+			text: "Transaction rejected. No funds were moved.",
+			className: "bg-system-red/10 text-system-red",
+		},
+		EXPIRED: {
+			icon: <WarningCircleIcon size={16} color="#808080" />,
+			text: "Transaction expired — no action was taken. No funds were moved.",
+			className: "bg-surface-grey/10 text-surface-grey",
+		},
+	};
+
+	const note = notes[view];
+	if (!note) return null;
+
+	return (
+		<div
+			className={clsx(
+				"w-full flex items-center gap-2 rounded px-3 py-2.5",
+				note.className
+			)}
+		>
+			<span className="shrink-0">{note.icon}</span>
+			<Caption className="font-bold">{note.text}</Caption>
+		</div>
+	);
+}

--- a/src/app/core/components/Modal/TransactionModal/VoteTransactionModal.tsx
+++ b/src/app/core/components/Modal/TransactionModal/VoteTransactionModal.tsx
@@ -21,6 +21,7 @@ const modalHeaderText: {
 	PREPARED: "Casting Vote",
 	SUBMITTED: "Casting Vote",
 	SAFE_SUBMITTED: "Casting Vote",
+	SAFE_EXPIRED: "Vote Expired",
 	CONFIRMED: "Vote casted",
 	REVERTED: "Something went wrong",
 };
@@ -31,6 +32,7 @@ const modalAdviceText: {
 	PREPARED: "Please confirm transaction in your wallet",
 	SUBMITTED: "Waiting for on-chain confimation",
 	SAFE_SUBMITTED: "Safe Transaction Submitted",
+	SAFE_EXPIRED: "Safe Transaction Expired",
 	CONFIRMED: "You have succesfully voted",
 	REVERTED: "Your vote did not go through, please try again",
 };

--- a/src/app/core/context/ModalContext.tsx
+++ b/src/app/core/context/ModalContext.tsx
@@ -26,6 +26,11 @@ export type BakeryTransactionModalState = {
   hash: string | null;
 };
 
+export type SafeTransactionModalState = {
+  type: "SAFE_TRANSACTION";
+  hash: string | null;
+};
+
 export type LPVaultTransactionModalState = {
   type: "LP_VAULT_TRANSACTION";
   transactionType: TransactionType;
@@ -47,6 +52,7 @@ export type GenericModalState = {
 
 export type ModalState =
   | BakeryTransactionModalState
+  | SafeTransactionModalState
   | VoteModalState
   | RecastModalState
   | ConfirmBurnModalState

--- a/src/app/core/context/TransactionsContext/SafeTransactionWatcher.tsx
+++ b/src/app/core/context/TransactionsContext/SafeTransactionWatcher.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef } from "react";
+import SafeAppsSDK, { TransactionStatus } from "@safe-global/safe-apps-sdk";
+import {
+	TSafeTransactionSubmitted,
+	TTransactionsDispatch,
+} from "./TransactionsReducer";
+import { useToast } from "../ToastContext/ToastContext";
+
+const POLL_INTERVAL_MS = 3000;
+
+/**
+ * A Safe transaction that sits unsigned for longer than this is treated as
+ * expired/timed-out, so the user gets clear feedback instead of an endless
+ * spinner. They can re-submit from the Safe transaction modal.
+ */
+const EXPIRY_TIMEOUT_MS = 1000 * 60 * 30; // 30 minutes
+
+/**
+ * Watches a Safe Wallet transaction by polling getBySafeTxHash every
+ * POLL_INTERVAL_MS milliseconds. Safe transactions don't resolve
+ * synchronously — they require multi-sig confirmation and return a
+ * safeTxHash instead of a regular on-chain txHash. Without this
+ * watcher, SAFE_SUBMITTED transactions get stuck "in process" forever.
+ *
+ * The watcher also surfaces signer progress (X of Y confirmations) and
+ * marks the transaction expired after EXPIRY_TIMEOUT_MS so the dedicated
+ * Safe transaction modal can render the full guided flow.
+ */
+export function SafeTransactionWatcher({
+	transaction,
+	transactionsDispatch,
+}: {
+	transaction: TSafeTransactionSubmitted;
+	transactionsDispatch: TTransactionsDispatch;
+}) {
+	const { hash } = transaction;
+	const typedHash = hash as `0x${string}`;
+	const { toastDispatch } = useToast();
+	const sdkRef = useRef(new SafeAppsSDK());
+
+	useEffect(() => {
+		toastDispatch({
+			type: "NEW",
+			payload: { toastType: "SUBMITTED", txHash: typedHash },
+		});
+	}, [typedHash, toastDispatch]);
+
+	useEffect(() => {
+		const sdk = sdkRef.current;
+		let intervalId: ReturnType<typeof setInterval>;
+		let expiryId: ReturnType<typeof setTimeout>;
+		let settled = false;
+
+		const stop = () => {
+			settled = true;
+			clearInterval(intervalId);
+			clearTimeout(expiryId);
+		};
+
+		const poll = async () => {
+			if (settled) return;
+			try {
+				const tx = await sdk.txs.getBySafeTxHash(typedHash);
+
+				// Surface signer progress (X of Y) for non-terminal states.
+				// Only multisig execution details carry confirmation counts.
+				const execInfo = tx.detailedExecutionInfo;
+				if (execInfo && "confirmationsRequired" in execInfo) {
+					transactionsDispatch({
+						type: "SET_SAFE_PROGRESS",
+						payload: {
+							hash: typedHash,
+							confirmationsSubmitted:
+								execInfo.confirmations?.length ?? 0,
+							confirmationsRequired:
+								execInfo.confirmationsRequired ?? 0,
+						},
+					});
+				}
+
+				if (tx.txStatus === TransactionStatus.SUCCESS) {
+					transactionsDispatch({
+						type: "SET_SUCCESS",
+						payload: { hash: typedHash },
+					});
+					stop();
+				} else if (
+					tx.txStatus === TransactionStatus.CANCELLED ||
+					tx.txStatus === TransactionStatus.FAILED
+				) {
+					transactionsDispatch({
+						type: "SET_REVERTED",
+						payload: { hash: typedHash },
+					});
+					toastDispatch({
+						type: "NEW",
+						payload: { toastType: "REVERTED", txHash: typedHash },
+					});
+					stop();
+				}
+				// AWAITING_CONFIRMATIONS and AWAITING_EXECUTION are non-terminal;
+				// keep polling.
+			} catch {
+				// SDK call failed — tx may not be indexed yet; keep polling.
+			}
+		};
+
+		expiryId = setTimeout(() => {
+			if (settled) return;
+			transactionsDispatch({
+				type: "SET_SAFE_EXPIRED",
+				payload: { hash: typedHash },
+			});
+			stop();
+		}, EXPIRY_TIMEOUT_MS);
+
+		poll();
+		intervalId = setInterval(poll, POLL_INTERVAL_MS);
+
+		return () => stop();
+	}, [typedHash, transactionsDispatch, toastDispatch]);
+
+	return null;
+}

--- a/src/app/core/context/TransactionsContext/TransactionsReducer.ts
+++ b/src/app/core/context/TransactionsContext/TransactionsReducer.ts
@@ -49,6 +49,15 @@ export type TSafeTransactionSubmitted = {
   status: "SAFE_SUBMITTED";
   data: TTransactionData;
   hash: TTransactionHash;
+  /** Number of owner signatures collected so far. */
+  confirmationsSubmitted?: number;
+  /** Threshold of owner signatures required to execute. */
+  confirmationsRequired?: number;
+};
+export type TSafeTransactionExpired = {
+  status: "SAFE_EXPIRED";
+  data: TTransactionData;
+  hash: TTransactionHash;
 };
 
 export type TTransaction =
@@ -56,7 +65,8 @@ export type TTransaction =
   | TTransactionSuccess
   | TTransactionPrepared
   | TTransactionReverted
-  | TSafeTransactionSubmitted;
+  | TSafeTransactionSubmitted
+  | TSafeTransactionExpired;
 
 export type TTransactionStatus = TTransaction["status"];
 
@@ -95,6 +105,18 @@ export type TTransactionsAction =
   | {
       type: "SET_SAFE_SUBMITTED";
       payload: { hash: TTransactionHash };
+    }
+  | {
+      type: "SET_SAFE_PROGRESS";
+      payload: {
+        hash: string;
+        confirmationsSubmitted: number;
+        confirmationsRequired: number;
+      };
+    }
+  | {
+      type: "SET_SAFE_EXPIRED";
+      payload: { hash: string };
     };
 
 export type TTransactionsDispatch = (action: TTransactionsAction) => void;
@@ -165,6 +187,33 @@ export function TransactionsReducer(
             hash: action.payload.hash,
           },
         ],
+      };
+    case "SET_SAFE_PROGRESS":
+      return {
+        ...state,
+        submitted: state.submitted.map((tx) => {
+          if (tx.hash === action.payload.hash && tx.status === "SAFE_SUBMITTED") {
+            return {
+              ...tx,
+              confirmationsSubmitted: action.payload.confirmationsSubmitted,
+              confirmationsRequired: action.payload.confirmationsRequired,
+            };
+          }
+          return tx;
+        }),
+      };
+    case "SET_SAFE_EXPIRED":
+      return {
+        ...state,
+        submitted: state.submitted.map((tx) => {
+          if (tx.hash === action.payload.hash) {
+            return {
+              ...tx,
+              status: "SAFE_EXPIRED",
+            };
+          }
+          return tx;
+        }),
       };
     case "CLEAR":
       return {

--- a/src/app/governance/components/CastVote.tsx
+++ b/src/app/governance/components/CastVote.tsx
@@ -161,6 +161,11 @@ export function CastVote({
 						type: "SET_SAFE_SUBMITTED",
 						payload: { hash },
 					});
+					// Safe votes need multi-sig approval inside the Safe app —
+					// route to the dedicated Safe transaction modal.
+					setModal({ type: "SAFE_TRANSACTION", hash });
+					setIsRecasting(false);
+					return;
 				}
 
 				setModal({ type: "VOTE_TRANSACTION", hash });


### PR DESCRIPTION
Closes #279

## Problem

When a Gnosis Safe wallet connects to the Solidarity Fund and initiates a transaction (bake, burn, governance vote), the standard wallet confirmation popup does nothing visible — Safe transactions require multi-sig approval inside the Safe app and return a `safeTxHash` instead of executing synchronously. The current UI gave no feedback, leaving users confused about why nothing happened after clicking confirm.

## What this PR does

Adds a dedicated, **Safe-aware modal** that detects the Safe wallet flow and guides the user through confirmation with bread-branded UI matching the [approved Figma designs](https://www.figma.com/design/B6pfKFiU3oVQRq7ACKcTmf/Bread-Solidarity-Fund) (`Solidarity Fund / Safe Module` page).

### New components
- **`SafeTransactionModal`** — single modal that renders all states:
  - **Pending** — explains the tx needs confirmation in Safe + `Open Safe App` deep link to the connected Safe's transaction queue (`app.safe.global/transactions/queue?safe=gno:<address>`)
  - **Waiting for signers** — live signer progress (`X of Y confirmations received`) with a progress bar
  - **Confirmed** — success state
  - **Rejected** — owners rejected the tx
  - **Expired** — not signed within the timeout window
- **`SafeIndicatorBadge`** — persistent nav indicator (ShieldCheck + "Safe", jade) shown whenever a Safe wallet is connected.

### Wiring
- **`SafeTransactionWatcher`** now also surfaces signer progress (from `detailedExecutionInfo`) and marks a tx **expired** after 30 min, alongside the existing success/revert polling.
- **`TransactionsReducer`** — adds `SAFE_EXPIRED` status, signer-progress fields, and `SET_SAFE_PROGRESS` / `SET_SAFE_EXPIRED` actions.
- Safe submissions from **Bake**, **Burn** (`ConfirmBurnModal`) and **Vote** (`CastVote`) now route to the new `SAFE_TRANSACTION` modal instead of the generic transaction modal.

## Design reference

Implements the states designed in #279 (desktop + mobile): Safe-detected nav indicator, Pending, Waiting for signers, Confirmed, Rejected, Expired.

## Testing
- `tsc --noEmit` — passes (0 errors)
- `next lint` — clean
- Reuses existing Safe detection (`useConnectedUser().isSafe`), wallet kit (wagmi + RainbowKit), and `@safe-global/safe-apps-sdk` already in the repo.

> Note: the Safe multi-sig flow is hard to exercise fully in local dev without a real Safe; manual QA with a connected Safe on Gnosis Chain is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)