### PR TITLE
fix: don't crash voting history on projects without metadata

### DIFF
--- a/src/app/governance/components/VotingHistory.tsx
+++ b/src/app/governance/components/VotingHistory.tsx
@@ -1,4 +1,4 @@
-import { projectsMeta } from "@/app/projectsMeta";
+import { getProjectMeta } from "@/app/projectsMeta";
 import { formatBalance, formatProjectPayment } from "@/app/core/util/formatter";
 import { formatUnits, Hex } from "viem";
 import { BreadIcon } from "@/app/core/components/Icons/TokenIcons";
@@ -263,7 +263,7 @@ function VotingHistoryDetailMobile({ sortedProjects }: Details) {
           collapsible
         >
           {sortedProjects.map(({ formatted, project }) => {
-            const meta = projectsMeta[project.projectAddress];
+            const meta = getProjectMeta(project.projectAddress);
 
             return (
               <Accordion.Item
@@ -274,13 +274,15 @@ function VotingHistoryDetailMobile({ sortedProjects }: Details) {
                 <Accordion.Trigger className="flex items-center justify-between w-full group">
                   <div className="inline-flex items-center justify-start w-4/6">
                     <div className="w-6 h-6 flex items-center justify-center bg-paper-0 border-[0.015rem] border-paper-2 mr-2">
-											<img
-												src={meta.logoSrc}
-												className="w-[1.2rem] h-[1.2rem]"
-												alt={`${meta.name}'s logo`}
-                        width={19.2}
-                        height={19.2}
-											/>
+											{meta.logoSrc ? (
+												<img
+													src={meta.logoSrc}
+													className="w-[1.2rem] h-[1.2rem]"
+													alt={`${meta.name}'s logo`}
+                          width={19.2}
+                          height={19.2}
+												/>
+											) : null}
 										</div>
                     <Body bold className="text-surface-grey mt-1">
                       {meta.name}
@@ -393,7 +395,7 @@ function VotingHistoryDetailDesktop({ sortedProjects }: Details) {
           </thead>
           <tbody>
             {sortedProjects.map(({ formatted, project }) => {
-              const meta = projectsMeta[project.projectAddress];
+              const meta = getProjectMeta(project.projectAddress);
               const vote = Number(formatted.percentVotes);
 
               return (
@@ -404,13 +406,15 @@ function VotingHistoryDetailDesktop({ sortedProjects }: Details) {
                   <td className="py-4 px-2">
                     <div className="flex items-center gap-2">
                       <div className="w-6 h-6 bg-paper-0 border-[0.015rem] border-paper-2 flex items-center justify-center">
-                        <img
-                          src={meta.logoSrc}
-                          className="w-[1.1625rem] h-[1.1625rem]"
-                          alt={`${meta.name}'s logo`}
-                          width={18.6}
-                          height={18.6}
-                        />
+                        {meta.logoSrc ? (
+                          <img
+                            src={meta.logoSrc}
+                            className="w-[1.1625rem] h-[1.1625rem]"
+                            alt={`${meta.name}'s logo`}
+                            width={18.6}
+                            height={18.6}
+                          />
+                        ) : null}
                       </div>
                       <Body bold className="text-surface-grey">
                         {meta.name}

--- a/src/app/projectsMeta.ts
+++ b/src/app/projectsMeta.ts
@@ -98,3 +98,28 @@ export const projectsMeta: {
     link: "https://www.karmahq.xyz/project/traditional-dream-factory-1/about",
   },
 };
+
+/**
+ * Returns metadata for a project address, falling back to a safe placeholder
+ * when the address has no entry in `projectsMeta`.
+ *
+ * Historical voting cycles can include former member projects that are no
+ * longer in `projectsMeta` (e.g. a project that was added and later removed
+ * from the YieldDistributor). Consumers that render distribution history
+ * (e.g. VotingHistory) must not assume every address is mapped — reading
+ * `.name`/`.logoSrc` off an undefined lookup crashes the view. Use this helper
+ * instead of indexing `projectsMeta` directly when the address may be historical.
+ */
+export function getProjectMeta(address: Hex): ProjectMeta {
+  const meta = projectsMeta[address];
+  if (meta) return meta;
+
+  return {
+    name: `${address.slice(0, 6)}…${address.slice(-4)}`,
+    order: Number.MAX_SAFE_INTEGER,
+    description: "Former member project.",
+    logoSrc: "",
+    active: false,
+    link: `https://gnosisscan.io/address/${address}`,
+  };
+}


### PR DESCRIPTION
## What

`VotingHistory` reads `projectsMeta[project.projectAddress].name` / `.logoSrc` **unconditionally** in both the desktop and mobile renderers. If a distribution includes an address that isn't in `projectsMeta`, the lookup is `undefined` and the whole history view crashes.

This adds a `getProjectMeta(address)` helper that returns the mapped metadata or a safe fallback (shortened address as the name, no logo, a gnosisscan link), and switches both renderers to use it — guarding the logo `<img>` so an empty `logoSrc` doesn't render a broken image.

## Why now

Heads-up: this is the frontend half of a cross-repo change. The subgraph is moving from hardcoded per-block-era project arrays to **event-sourced** project attribution (BreadchainCoop/subgraph#6). That fix is more correct historically — and it surfaces a former member project, `0x9c8c8513974d22e8ea9f74f2860833db107111e6`, in ~5 early cycles that the old hardcoded config silently hid. That address has no `projectsMeta` entry, so without this guard the history view would start crashing on those cycles once subgraph#6 deploys.

It also future-proofs the page: if a new project is added on-chain before someone updates `projectsMeta`, history degrades gracefully instead of crashing.

## Note on "moving names to the frontend"

For context — the project names already live here in `projectsMeta.ts`, and **Traditional Dream Factory was already added** (commit 709a983, Apr 16), logo asset included. So there was nothing to migrate from the subgraph (it never carried names). This PR is the genuinely-needed frontend follow-up that the subgraph rework surfaced.

❓ Open question: if you'd rather `0x9c8c…111e6` show a real label instead of a shortened address, give me the name and I'll add a proper `projectsMeta` entry (with `active: false`).

## Test

- `tsc --noEmit`: clean.
- `pnpm lint`: clean on the changed files.
- Behavior: mapped projects render exactly as before; unmapped addresses now show a truncated address with a neutral placeholder box instead of crashing.
