### PR TITLE
In-app Peer onramp via @zkp2p/sdk (Buyer TEE, headless)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@ NEXT_PUBLIC_QUIKNODE_API_KEY=
 NEXT_PUBLIC_ALCHEMY_MAINNET_API_KEY=
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=
 NEXT_PUBLIC_SUBGRAPH_API_KEY=
+# Mt Pelerin partner activation key (developers.mtpelerin.com). Use the docs' local test key when developing.
+NEXT_PUBLIC_MTPELERIN_ACTIVATION_KEY=
 # synpress
 PRIVATE_KEY=
 NEXT_PUBLIC_TEST_CONNECTOR=true

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tanstack/react-query-devtools": "^5.66.7",
     "@wagmi/connectors": "^5.7.7",
     "@wagmi/core": "^2.16.4",
+    "@zkp2p/sdk": "^0.7.2",
     "blo": "^1.1.1",
     "clsx": "^2.1.0",
     "date-fns": "^3.6.0",
@@ -47,7 +48,7 @@
     "react-tooltip": "^5.28.0",
     "tailwindcss": "^4.2.4",
     "typescript": "^5.9.3",
-    "viem": "^2.30.1",
+    "viem": "^2.37.3",
     "wagmi": "^2.16.9"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 0.2.5
       '@lifi/widget':
         specifier: ^3.30.0
-        version: 3.35.1(kmicii6jurjs3gvsjokeib25la)
+        version: 3.35.1(@bigmi/react@0.6.3(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bs58@6.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0)))(@mysten/dapp-kit@0.19.9(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(@solana/wallet-adapter-react@0.15.39(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bs58@6.0.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(wagmi@2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(zod@3.25.76)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -58,10 +58,13 @@ importers:
         version: 5.91.1(@tanstack/react-query@5.90.11(react@19.2.0))(react@19.2.0)
       '@wagmi/connectors':
         specifier: ^5.7.7
-        version: 5.11.2(aajrplqwcswjsciyijkbnwbnwy)
+        version: 5.11.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(zod@3.25.76)
       '@wagmi/core':
         specifier: ^2.16.4
         version: 2.22.1(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@zkp2p/sdk':
+        specifier: ^0.7.2
+        version: 0.7.2(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       blo:
         specifier: ^1.1.1
         version: 1.2.0
@@ -105,7 +108,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       viem:
-        specifier: ^2.30.1
+        specifier: ^2.37.3
         version: 2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       wagmi:
         specifier: ^2.16.9
@@ -2068,6 +2071,43 @@ packages:
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'The package is now available as "qr": npm install qr'
 
+  '@peculiar/asn1-cms@2.8.0':
+    resolution: {integrity: sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==}
+
+  '@peculiar/asn1-csr@2.8.0':
+    resolution: {integrity: sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==}
+
+  '@peculiar/asn1-ecc@2.8.0':
+    resolution: {integrity: sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==}
+
+  '@peculiar/asn1-pfx@2.8.0':
+    resolution: {integrity: sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==}
+
+  '@peculiar/asn1-pkcs8@2.8.0':
+    resolution: {integrity: sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==}
+
+  '@peculiar/asn1-pkcs9@2.8.0':
+    resolution: {integrity: sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==}
+
+  '@peculiar/asn1-rsa@2.8.0':
+    resolution: {integrity: sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==}
+
+  '@peculiar/asn1-schema@2.8.0':
+    resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
+
+  '@peculiar/asn1-x509-attr@2.8.0':
+    resolution: {integrity: sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==}
+
+  '@peculiar/asn1-x509@2.8.0':
+    resolution: {integrity: sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==}
+
+  '@peculiar/utils@2.0.3':
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+
+  '@peculiar/x509@1.14.3':
+    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
+    engines: {node: '>=20.0.0'}
+
   '@phosphor-icons/react@2.1.10':
     resolution: {integrity: sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==}
     engines: {node: '>=10'}
@@ -3455,6 +3495,9 @@ packages:
   '@types/node@20.19.25':
     resolution: {integrity: sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==}
 
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -3904,6 +3947,30 @@ packages:
   '@zeit/schemas@2.36.0':
     resolution: {integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==}
 
+  '@zkp2p/contracts-v2@0.2.4':
+    resolution: {integrity: sha512-2MIPKWdKYCcgA/BjoasJh0VdTvP25UYyDi0TyTMx/8Z+6Qc/wzWnJTRMOzUP07P069XoQ2sTCcgS246Rb9AiHw==}
+    peerDependencies:
+      ethers: ^5.0.0 || ^6.0.0
+
+  '@zkp2p/indexer-schema@0.5.0':
+    resolution: {integrity: sha512-L2ShEBv7HjghRElZSYtGcBNdnRVchVW7c/wnN3S5VLZQA4V2IUmVv8BPZzYYiQ53y+7F/qPKtUQOW+p9ZbZEiQ==}
+    engines: {node: '>=16'}
+
+  '@zkp2p/sdk@0.7.2':
+    resolution: {integrity: sha512-ZtRMfnI4LOUHZ+pYGjTi6rxQsch1kDFeTLIeRd7ytARWW1GT3+7qeXmT7FSxvq8sJCyrNkY6xmnLirtsC6De5Q==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      react: '>=16.8.0'
+      viem: ^2.37.3
+    peerDependenciesMeta:
+      react:
+        optional: true
+
+  '@zkp2p/zkp2p-attestation@1.6.3':
+    resolution: {integrity: sha512-gGBNrbULr/livdR7wkyDto+zRVsAxIBUx6YBT+VEFW5stgZBwxv6sEuQ4AguBnmSe9WKFrWZWYC3fLgdFcPT6g==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   abitype@0.9.8:
     resolution: {integrity: sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==}
     peerDependencies:
@@ -3959,6 +4026,17 @@ packages:
       zod:
         optional: true
 
+  abitype@1.2.4:
+    resolution: {integrity: sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -3991,6 +4069,9 @@ packages:
   address@1.2.2:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
     engines: {node: '>= 10.0.0'}
+
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
 
   agent-base@5.1.1:
     resolution: {integrity: sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==}
@@ -4128,6 +4209,10 @@ packages:
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -5213,6 +5298,10 @@ packages:
 
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
+
+  ethers@6.17.0:
+    resolution: {integrity: sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==}
+    engines: {node: '>=14.0.0'}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -6838,6 +6927,14 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  ox@0.11.3:
+    resolution: {integrity: sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ox@0.6.7:
     resolution: {integrity: sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==}
     peerDependencies:
@@ -7218,6 +7315,13 @@ packages:
     resolution: {integrity: sha512-n13AWriBMPYxnpbb6bnaY5YoY6rGj8vPLrz6CZF3o0qJNEwlcfJVxBzYZ0NJsQ21UbdJoijPCDrM++SUVEz7+w==}
     engines: {node: '>=8.16.0'}
 
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
+
   qr@0.5.3:
     resolution: {integrity: sha512-BSrGdNXa8z6PfEYWtvITV21mQ4asR4UCj38Fa3MUUoFAtYzFK/swEQXF+OeBuNbHPFfs3PzpZuK0BXizWXgFOQ==}
     engines: {node: '>= 20.19.0'}
@@ -7440,6 +7544,9 @@ packages:
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -8062,6 +8169,9 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -8069,6 +8179,10 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -8162,6 +8276,9 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -8354,6 +8471,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valibot@0.36.0:
@@ -8594,6 +8712,18 @@ packages:
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -10333,8 +10463,8 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@lifi/wallet-management@3.19.3(dilqfnubnv27k4ak3su5pdef7a)':
-    dependencies:
+  ? '@lifi/wallet-management@3.19.3(@bigmi/react@0.6.3(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bs58@6.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0)))(@mysten/dapp-kit@0.19.9(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(@solana/wallet-adapter-react@0.15.39(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bs58@6.0.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(wagmi@2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(zod@3.25.76)'
+  : dependencies:
       '@bigmi/client': 0.6.3(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(bs58@6.0.0)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.0))
       '@bigmi/core': 0.6.3(@types/react@18.3.27)(bs58@6.0.0)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.0))
       '@bigmi/react': 0.6.3(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bs58@6.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))
@@ -10375,15 +10505,15 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@lifi/widget@3.35.1(kmicii6jurjs3gvsjokeib25la)':
-    dependencies:
+  ? '@lifi/widget@3.35.1(@bigmi/react@0.6.3(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bs58@6.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0)))(@mysten/dapp-kit@0.19.9(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(@solana/wallet-adapter-react@0.15.39(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bs58@6.0.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(wagmi@2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(zod@3.25.76)'
+  : dependencies:
       '@bigmi/client': 0.6.3(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(bs58@6.0.0)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))
       '@bigmi/core': 0.6.3(@types/react@18.3.27)(bs58@6.0.0)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))
       '@bigmi/react': 0.6.3(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bs58@6.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))
       '@emotion/react': 11.14.0(@types/react@18.3.27)(react@19.2.0)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@19.2.0))(@types/react@18.3.27)(react@19.2.0)
       '@lifi/sdk': 3.13.5(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
-      '@lifi/wallet-management': 3.19.3(dilqfnubnv27k4ak3su5pdef7a)
+      '@lifi/wallet-management': 3.19.3(@bigmi/react@0.6.3(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bs58@6.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0)))(@mysten/dapp-kit@0.19.9(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(@solana/wallet-adapter-react@0.15.39(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bs58@6.0.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(wagmi@2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(zod@3.25.76)
       '@mui/icons-material': 7.3.5(@mui/material@7.3.5(@emotion/react@11.14.0(@types/react@18.3.27)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@19.2.0))(@types/react@18.3.27)(react@19.2.0))(@types/react@18.3.27)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@types/react@18.3.27)(react@19.2.0)
       '@mui/material': 7.3.5(@emotion/react@11.14.0(@types/react@18.3.27)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@19.2.0))(@types/react@18.3.27)(react@19.2.0))(@types/react@18.3.27)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@mui/system': 7.3.5(@emotion/react@11.14.0(@types/react@18.3.27)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@19.2.0))(@types/react@18.3.27)(react@19.2.0))(@types/react@18.3.27)(react@19.2.0)
@@ -11180,6 +11310,100 @@ snapshots:
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
 
   '@paulmillr/qr@0.2.1': {}
+
+  '@peculiar/asn1-cms@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-csr@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-ecc@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pfx@2.8.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs8@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs9@2.8.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pfx': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-schema@2.8.0':
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509-attr@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/utils@2.0.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@peculiar/x509@1.14.3':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-csr': 2.8.0
+      '@peculiar/asn1-ecc': 2.8.0
+      '@peculiar/asn1-pkcs9': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      pvtsutils: 1.3.6
+      reflect-metadata: 0.2.2
+      tslib: 2.8.1
+      tsyringe: 4.10.0
 
   '@phosphor-icons/react@2.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -12008,7 +12232,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -13406,6 +13630,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/parse-json@4.0.2': {}
@@ -13641,8 +13869,8 @@ snapshots:
     dependencies:
       '@vanilla-extract/css': 1.17.3(babel-plugin-macros@3.1.0)
 
-  '@wagmi/connectors@5.11.2(aajrplqwcswjsciyijkbnwbnwy)':
-    dependencies:
+  ? '@wagmi/connectors@5.11.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(zod@3.25.76)'
+  : dependencies:
       '@base-org/account': 1.1.1(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@gemini-wallet/core': 0.2.0(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
@@ -13652,7 +13880,7 @@ snapshots:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@walletconnect/ethereum-provider': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.19(3zbcxdnhyrj6e2mwol3vqlexva)
+      porto: 0.2.19(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
       viem: 2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
@@ -13688,8 +13916,8 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/connectors@6.2.0(4zudybgs7pzawk7pokep2guqzi)':
-    dependencies:
+  ? '@wagmi/connectors@6.2.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)'
+  : dependencies:
       '@base-org/account': 2.4.0(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@gemini-wallet/core': 0.3.2(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
@@ -13699,7 +13927,7 @@ snapshots:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@walletconnect/ethereum-provider': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(p46uokhoqit3rig6ts2i3pecym)
+      porto: 0.2.35(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
       viem: 2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
@@ -14420,6 +14648,40 @@ snapshots:
 
   '@zeit/schemas@2.36.0': {}
 
+  '@zkp2p/contracts-v2@0.2.4(ethers@6.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(zod@3.25.76)':
+    dependencies:
+      abitype: 1.2.0(typescript@5.9.3)(zod@3.25.76)
+      ethers: 6.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - typescript
+      - zod
+
+  '@zkp2p/indexer-schema@0.5.0': {}
+
+  '@zkp2p/sdk@0.7.2(bufferutil@4.0.9)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      '@zkp2p/contracts-v2': 0.2.4(ethers@6.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(zod@3.25.76)
+      '@zkp2p/indexer-schema': 0.5.0
+      '@zkp2p/zkp2p-attestation': 1.6.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ethers: 6.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ox: 0.11.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+    optionalDependencies:
+      react: 19.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@zkp2p/zkp2p-attestation@1.6.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@peculiar/x509': 1.14.3
+      ethers: 6.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   abitype@0.9.8(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.3
@@ -14445,6 +14707,11 @@ snapshots:
       typescript: 5.9.3
       zod: 3.25.76
 
+  abitype@1.2.0(typescript@5.9.3)(zod@3.22.4):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 3.22.4
+
   abitype@1.2.0(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.3
@@ -14454,6 +14721,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
       zod: 4.1.13
+
+  abitype@1.2.4(typescript@5.9.3)(zod@3.25.76):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 3.25.76
 
   abort-controller@3.0.0:
     dependencies:
@@ -14479,6 +14751,8 @@ snapshots:
   acorn@8.15.0: {}
 
   address@1.2.2: {}
+
+  aes-js@4.0.0-beta.5: {}
 
   agent-base@5.1.1: {}
 
@@ -14642,6 +14916,12 @@ snapshots:
       is-array-buffer: 3.0.5
 
   asap@2.0.6: {}
+
+  asn1js@3.0.10:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
 
   ast-types-flow@0.0.8: {}
 
@@ -15949,6 +16229,19 @@ snapshots:
       '@noble/hashes': 1.4.0
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
+
+  ethers@6.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   event-target-shim@5.0.1: {}
 
@@ -17921,14 +18214,29 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  ox@0.11.3(typescript@5.9.3)(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@5.9.3)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
   ox@0.6.7(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
-      '@noble/curves': 1.8.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.0(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -17972,7 +18280,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.9.3)(zod@3.22.4)
+      abitype: 1.2.0(typescript@5.9.3)(zod@3.22.4)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -17987,7 +18295,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.0(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -18180,8 +18488,8 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.19(3zbcxdnhyrj6e2mwol3vqlexva):
-    dependencies:
+  ? porto@0.2.19(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
+  : dependencies:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hono: 4.10.7
       idb-keyval: 6.2.2
@@ -18200,8 +18508,8 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  porto@0.2.35(p46uokhoqit3rig6ts2i3pecym):
-    dependencies:
+  ? porto@0.2.35(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
+  : dependencies:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hono: 4.10.7
       idb-keyval: 6.2.2
@@ -18333,6 +18641,12 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.1.5: {}
 
   qr@0.5.3: {}
 
@@ -18619,6 +18933,8 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
+
+  reflect-metadata@0.2.2: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -19377,6 +19693,8 @@ snapshots:
 
   tslib@1.14.1: {}
 
+  tslib@2.7.0: {}
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -19385,6 +19703,10 @@ snapshots:
       get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  tsyringe@4.10.0:
+    dependencies:
+      tslib: 1.14.1
 
   type-check@0.4.0:
     dependencies:
@@ -19471,6 +19793,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@5.26.5: {}
+
+  undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
 
@@ -19747,7 +20071,7 @@ snapshots:
   wagmi@2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       '@tanstack/react-query': 5.90.11(react@19.2.0)
-      '@wagmi/connectors': 6.2.0(4zudybgs7pzawk7pokep2guqzi)
+      '@wagmi/connectors': 6.2.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.11)(@tanstack/react-query@5.90.11(react@19.2.0))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.11)(@types/react@18.3.27)(react@19.2.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       react: 19.2.0
       use-sync-external-store: 1.4.0(react@19.2.0)
@@ -19964,6 +20288,11 @@ snapshots:
       utf-8-validate: 5.0.10
 
   ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 5.0.10
+
+  ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10

--- a/src/app/bakery/components/Swap/Buy.tsx
+++ b/src/app/bakery/components/Swap/Buy.tsx
@@ -20,7 +20,7 @@ export function Buy() {
     <div>
       <ProviderPicker provider={provider} setProvider={setProvider} />
       {provider === "PEER" ? (
-        <PeerBuy />
+        <PeerBuy recipientAddress={recipientAddress} />
       ) : (
         <MtPelerinBuy amount={amount} onAmountChange={setAmount} recipientAddress={recipientAddress} />
       )}

--- a/src/app/bakery/components/Swap/Buy.tsx
+++ b/src/app/bakery/components/Swap/Buy.tsx
@@ -1,129 +1,29 @@
 "use client";
 
-import { useState, ChangeEvent } from "react";
-import { Body, LiftedButton } from "@breadcoop/ui";
-import { buildPeerUrl } from "@/lib/peer";
-import { sanitizeInputValue } from "@/app/core/util/sanitizeInput";
+import { useState } from "react";
 import { useConnectedUser } from "@/app/core/hooks/useConnectedUser";
 import { isAddress } from "viem";
-import { useStrictMobile } from "@/hooks/use-is-device";
+import { ProviderPicker } from "./ProviderPicker";
+import { PeerBuy } from "./PeerBuy";
+import { MtPelerinBuy } from "./MtPelerinBuy";
+import { TBuyProvider } from "./interfaces";
 
 export function Buy() {
+  const [provider, setProvider] = useState<TBuyProvider>("PEER");
   const [amount, setAmount] = useState("");
-  const { isMobile } = useStrictMobile();
   const { user } = useConnectedUser();
 
-  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const sanitizedValue = sanitizeInputValue(event.target.value);
-    setAmount(sanitizedValue);
-  };
-
-  const handleBuy = () => {
-    let recipientAddress: string | undefined = undefined;
-
-    // Validate and use recipient address only if user is connected and address is valid
-    if (user.status === "CONNECTED" && isAddress(user.address)) {
-      recipientAddress = user.address;
-    }
-
-    const url = buildPeerUrl({
-      ...(amount && { inputAmount: amount }),
-      ...(recipientAddress && { recipientAddress }),
-    });
-    window.open(url, "_blank");
-  };
+  const recipientAddress =
+    user.status === "CONNECTED" && isAddress(user.address) ? user.address : undefined;
 
   return (
-    <div className="space-y-4">
-      <div className="bg-paper-1 p-5">
-        <div id="peer-description">
-          <div className="text-surface-grey-2 text-sm mb-4">
-            <>
-              <div className="flex items-center gap-3 mb-4">
-                <img src="https://www.peer.xyz/logo192.png" alt="Peer" className="h-10 w-10" />
-                <Body className="text-base font-bold text-surface-ink">Buy with Peer</Body>
-              </div>
-              {isMobile ? (
-                <>
-                  <Body className="text-sm mb-3">
-                    This feature is only available on desktop devices.
-                  </Body>
-                  <Body className="text-sm mb-4">
-                    <LearnMoreLink />
-                  </Body>
-                </>
-              ) : (
-                <>
-                  <Body className="text-sm mb-3">
-                    Peer is a service where you can buy crypto without KYC using various neobanking applications.
-                  </Body>
-                  <Body className="text-sm mb-3">
-                    Insert the amount of xDAI you would like to purchase and bake into BREAD, then continue the process by clicking the buy button below.
-                  </Body>
-                  <Body className="text-sm mb-3">
-                    You will need to download a browser extension called <a href="https://chromewebstore.google.com/detail/peerauth-authenticate-and/ijpgccednehjpeclfcllnjjcmiohdjih" target="_blank" rel="noopener noreferrer" className="text-primary-orange hover:underline">PeerAuth</a> in order to complete your purchase.
-                  </Body>
-                  <Body className="text-sm mb-4">
-                    <LearnMoreLink />
-                  </Body>
-                  <Body className="text-sm flex items-center gap-2 mt-4">
-                    <span className="text-xs font-semibold text-surface-grey">Supported apps:</span>
-                    <span className="text-xs text-surface-grey-2">Venmo, Revolut, Wise, Cash App, Zelle, N26, and more</span>
-                  </Body>
-                </>
-              )}
-            </>
-          </div>
-        </div>
-
-        {!isMobile && (
-          <form onSubmit={e => e.preventDefault} id="peer-form" className="space-y-2">
-            <label className="text-sm font-bold text-black">
-              Amount (USD) - Optional
-            </label>
-            <input
-              type="text"
-              value={amount}
-              onChange={handleInputChange}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault();
-                }
-              }}
-              placeholder="Enter amount or leave blank"
-              className="w-full p-3 border border-surface-grey bg-white text-black placeholder:text-surface-grey-2 focus:outline-none focus:border-[#EA5817]"
-            />
-          </form>
-        )}
-      </div>
-
-      <div
-        className={`relative lifted-button-container ${isMobile ? "opacity-50 cursor-not-allowed pointer-events-none" : ""}`}
-        aria-disabled={isMobile}
-        aria-describedby={isMobile ? "peer-description" : undefined}
-      >
-        <LiftedButton
-          onClick={handleBuy}
-          disabled={isMobile}
-          className=""
-          form="peer-form"
-        >
-          Buy with Peer
-        </LiftedButton>
-      </div>
+    <div>
+      <ProviderPicker provider={provider} setProvider={setProvider} />
+      {provider === "PEER" ? (
+        <PeerBuy amount={amount} onAmountChange={setAmount} recipientAddress={recipientAddress} />
+      ) : (
+        <MtPelerinBuy amount={amount} onAmountChange={setAmount} recipientAddress={recipientAddress} />
+      )}
     </div>
   );
-}
-
-function LearnMoreLink() {
-	return (
-		<a
-			href="https://docs.peer.xyz/guides/for-buyers/complete-guide-to-onboarding"
-			className="text-primary-orange hover:underline"
-			target="_blank"
-			rel="noopener noreferrer"
-		>
-			Learn more about the process →
-		</a>
-	);
 }

--- a/src/app/bakery/components/Swap/Buy.tsx
+++ b/src/app/bakery/components/Swap/Buy.tsx
@@ -20,7 +20,7 @@ export function Buy() {
     <div>
       <ProviderPicker provider={provider} setProvider={setProvider} />
       {provider === "PEER" ? (
-        <PeerBuy amount={amount} onAmountChange={setAmount} recipientAddress={recipientAddress} />
+        <PeerBuy />
       ) : (
         <MtPelerinBuy amount={amount} onAmountChange={setAmount} recipientAddress={recipientAddress} />
       )}

--- a/src/app/bakery/components/Swap/Buy.tsx
+++ b/src/app/bakery/components/Swap/Buy.tsx
@@ -9,7 +9,7 @@ import { MtPelerinBuy } from "./MtPelerinBuy";
 import { TBuyProvider } from "./interfaces";
 
 export function Buy() {
-  const [provider, setProvider] = useState<TBuyProvider>("PEER");
+  const [provider, setProvider] = useState<TBuyProvider>("MT_PELERIN");
   const [amount, setAmount] = useState("");
   const { user } = useConnectedUser();
 

--- a/src/app/bakery/components/Swap/MtPelerinBuy.tsx
+++ b/src/app/bakery/components/Swap/MtPelerinBuy.tsx
@@ -31,7 +31,7 @@ export function MtPelerinBuy({
       <div className="bg-paper-1 p-5">
         <div className="text-surface-grey-2 text-sm mb-4">
           <div className="flex items-center gap-3 mb-4">
-            <img src="https://www.mtpelerin.com/favicon.ico" alt="Mt Pelerin" className="h-10 w-10" />
+            <img src="https://www.mtpelerin.com/icons/android-chrome-192x192.png" alt="Mt Pelerin" className="h-10 w-10" />
             <Body className="text-base font-bold text-surface-ink">Buy with Mt Pelerin</Body>
           </div>
           <Body className="text-sm mb-3">

--- a/src/app/bakery/components/Swap/MtPelerinBuy.tsx
+++ b/src/app/bakery/components/Swap/MtPelerinBuy.tsx
@@ -52,7 +52,7 @@ export function MtPelerinBuy({
                 <li>Click the button below to open Mt Pelerin&apos;s xDAI page</li>
                 <li>Choose the amount you want to buy</li>
                 <li>Enter your wallet address as the receiving address</li>
-                <li>Pay by bank transfer &mdash; your xDAI arrives in your wallet, ready to bake into BREAD</li>
+                <li>Pay by bank transfer, or by card if you verify your identity &mdash; your xDAI arrives in your wallet, ready to bake into BREAD</li>
               </ol>
             </div>
           )}

--- a/src/app/bakery/components/Swap/MtPelerinBuy.tsx
+++ b/src/app/bakery/components/Swap/MtPelerinBuy.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { ChangeEvent } from "react";
+import { ChangeEvent, useState } from "react";
 import { Body, LiftedButton } from "@breadcoop/ui";
-import { buildMtPelerinUrl } from "@/lib/mtPelerin";
+import { buildMtPelerinUrl, hasMtPelerinKey } from "@/lib/mtPelerin";
 import { sanitizeInputValue } from "@/app/core/util/sanitizeInput";
 
 export function MtPelerinBuy({
@@ -35,39 +35,88 @@ export function MtPelerinBuy({
             <Body className="text-base font-bold text-surface-ink">Buy with Mt Pelerin</Body>
           </div>
           <Body className="text-sm mb-3">
-            Mt Pelerin is a Swiss fiat-to-crypto service that buys xDAI directly on Gnosis Chain. No ID is required for card purchases up to roughly 5,000 CHF/EUR/GBP, or bank transfers under CHF 100,000.
+            Mt Pelerin is a Swiss service for buying xDAI directly on Gnosis Chain. Bank transfers (SEPA, Swiss) need no ID verification up to roughly 1,000 CHF/EUR per month &mdash; just an email and phone number. Card purchases and larger amounts require identity verification.
           </Body>
           <Body className="text-sm mb-3">
-            Insert the amount of xDAI you would like to purchase and bake into BREAD, then continue the process by clicking the buy button below.
+            Not available to US residents &mdash; use Peer instead.
           </Body>
-          <Body className="text-sm mb-4">
-            Your purchase completes on Mt Pelerin&apos;s site &mdash; once done, your xDAI should arrive in your wallet shortly.
-          </Body>
+          {hasMtPelerinKey ? (
+            <Body className="text-sm mb-3">
+              Insert the amount of xDAI you would like to purchase and bake into BREAD, then continue the process by clicking the buy button below.
+            </Body>
+          ) : (
+            <div className="mb-3">
+              <Body className="text-sm mb-2 font-bold text-surface-ink">How it works:</Body>
+              <ol className="text-sm list-decimal list-inside space-y-1">
+                <li>Click the button below to open Mt Pelerin&apos;s xDAI page</li>
+                <li>Choose the amount you want to buy</li>
+                <li>Enter your wallet address as the receiving address</li>
+                <li>Pay by bank transfer &mdash; your xDAI arrives in your wallet, ready to bake into BREAD</li>
+              </ol>
+            </div>
+          )}
+          {!hasMtPelerinKey && recipientAddress && (
+            <WalletAddressHint address={recipientAddress} />
+          )}
         </div>
 
-        <form onSubmit={e => e.preventDefault()} id="mtpelerin-form" className="space-y-2">
-          <label className="text-sm font-bold text-black">
-            Amount (USD) - Optional
-          </label>
-          <input
-            type="text"
-            value={amount}
-            onChange={handleInputChange}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-              }
-            }}
-            placeholder="Enter amount or leave blank"
-            className="w-full p-3 border border-surface-grey bg-white text-black placeholder:text-surface-grey-2 focus:outline-none focus:border-[#EA5817]"
-          />
-        </form>
+        {hasMtPelerinKey && (
+          <form onSubmit={e => e.preventDefault()} id="mtpelerin-form" className="space-y-2">
+            <label className="text-sm font-bold text-black">
+              Amount (USD) - Optional
+            </label>
+            <input
+              type="text"
+              value={amount}
+              onChange={handleInputChange}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                }
+              }}
+              placeholder="Enter amount or leave blank"
+              className="w-full p-3 border border-surface-grey bg-white text-black placeholder:text-surface-grey-2 focus:outline-none focus:border-[#EA5817]"
+            />
+          </form>
+        )}
       </div>
 
       <div className="relative lifted-button-container">
-        <LiftedButton onClick={handleBuy} className="" form="mtpelerin-form">
+        <LiftedButton onClick={handleBuy} className="" form={hasMtPelerinKey ? "mtpelerin-form" : undefined}>
           Buy with Mt Pelerin
         </LiftedButton>
+      </div>
+    </div>
+  );
+}
+
+function WalletAddressHint({ address }: { address: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable (e.g. insecure context) — user can select the text manually
+    }
+  };
+
+  return (
+    <div className="bg-paper-main p-3 mt-3">
+      <Body className="text-xs font-semibold text-surface-grey mb-1">
+        Your wallet address (for step 3):
+      </Body>
+      <div className="flex items-center gap-2">
+        <code className="text-xs text-surface-ink break-all">{address}</code>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="text-xs font-bold text-primary-orange hover:underline shrink-0"
+        >
+          {copied ? "Copied!" : "Copy"}
+        </button>
       </div>
     </div>
   );

--- a/src/app/bakery/components/Swap/MtPelerinBuy.tsx
+++ b/src/app/bakery/components/Swap/MtPelerinBuy.tsx
@@ -2,7 +2,7 @@
 
 import { ChangeEvent } from "react";
 import { Body, LiftedButton } from "@breadcoop/ui";
-import { buildMtPelerinUrl } from "@/lib/mtPelerin";
+import { buildMtPelerinUrl, hasMtPelerinKey } from "@/lib/mtPelerin";
 import { sanitizeInputValue } from "@/app/core/util/sanitizeInput";
 
 export function MtPelerinBuy({
@@ -37,31 +37,39 @@ export function MtPelerinBuy({
           <Body className="text-sm mb-3">
             Mt Pelerin is a Swiss fiat-to-crypto service that buys xDAI directly on Gnosis Chain. No ID is required for card purchases up to roughly 5,000 CHF/EUR/GBP, or bank transfers under CHF 100,000.
           </Body>
-          <Body className="text-sm mb-3">
-            Insert the amount of xDAI you would like to purchase and bake into BREAD, then continue the process by clicking the buy button below.
-          </Body>
+          {hasMtPelerinKey ? (
+            <Body className="text-sm mb-3">
+              Insert the amount of xDAI you would like to purchase and bake into BREAD, then continue the process by clicking the buy button below.
+            </Body>
+          ) : (
+            <Body className="text-sm mb-3">
+              Clicking the buy button opens Mt Pelerin&apos;s site, where you choose the amount and enter the wallet address to receive your xDAI.
+            </Body>
+          )}
           <Body className="text-sm mb-4">
             Your purchase completes on Mt Pelerin&apos;s site &mdash; once done, your xDAI should arrive in your wallet shortly.
           </Body>
         </div>
 
-        <form onSubmit={e => e.preventDefault()} id="mtpelerin-form" className="space-y-2">
-          <label className="text-sm font-bold text-black">
-            Amount (USD) - Optional
-          </label>
-          <input
-            type="text"
-            value={amount}
-            onChange={handleInputChange}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-              }
-            }}
-            placeholder="Enter amount or leave blank"
-            className="w-full p-3 border border-surface-grey bg-white text-black placeholder:text-surface-grey-2 focus:outline-none focus:border-[#EA5817]"
-          />
-        </form>
+        {hasMtPelerinKey && (
+          <form onSubmit={e => e.preventDefault()} id="mtpelerin-form" className="space-y-2">
+            <label className="text-sm font-bold text-black">
+              Amount (USD) - Optional
+            </label>
+            <input
+              type="text"
+              value={amount}
+              onChange={handleInputChange}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                }
+              }}
+              placeholder="Enter amount or leave blank"
+              className="w-full p-3 border border-surface-grey bg-white text-black placeholder:text-surface-grey-2 focus:outline-none focus:border-[#EA5817]"
+            />
+          </form>
+        )}
       </div>
 
       <div className="relative lifted-button-container">

--- a/src/app/bakery/components/Swap/MtPelerinBuy.tsx
+++ b/src/app/bakery/components/Swap/MtPelerinBuy.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { ChangeEvent } from "react";
+import { Body, LiftedButton } from "@breadcoop/ui";
+import { buildMtPelerinUrl } from "@/lib/mtPelerin";
+import { sanitizeInputValue } from "@/app/core/util/sanitizeInput";
+
+export function MtPelerinBuy({
+  amount,
+  onAmountChange,
+  recipientAddress,
+}: {
+  amount: string;
+  onAmountChange: (amount: string) => void;
+  recipientAddress?: string;
+}) {
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onAmountChange(sanitizeInputValue(event.target.value));
+  };
+
+  const handleBuy = () => {
+    const url = buildMtPelerinUrl({
+      ...(amount && { inputAmount: amount }),
+      ...(recipientAddress && { recipientAddress }),
+    });
+    window.open(url, "_blank");
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-paper-1 p-5">
+        <div className="text-surface-grey-2 text-sm mb-4">
+          <div className="flex items-center gap-3 mb-4">
+            <img src="https://www.mtpelerin.com/favicon.ico" alt="Mt Pelerin" className="h-10 w-10" />
+            <Body className="text-base font-bold text-surface-ink">Buy with Mt Pelerin</Body>
+          </div>
+          <Body className="text-sm mb-3">
+            Mt Pelerin is a Swiss fiat-to-crypto service that buys xDAI directly on Gnosis Chain. No ID is required for card purchases up to roughly 5,000 CHF/EUR/GBP, or bank transfers under CHF 100,000.
+          </Body>
+          <Body className="text-sm mb-3">
+            Insert the amount of xDAI you would like to purchase and bake into BREAD, then continue the process by clicking the buy button below.
+          </Body>
+          <Body className="text-sm mb-4">
+            Your purchase completes on Mt Pelerin&apos;s site &mdash; once done, your xDAI should arrive in your wallet shortly.
+          </Body>
+        </div>
+
+        <form onSubmit={e => e.preventDefault()} id="mtpelerin-form" className="space-y-2">
+          <label className="text-sm font-bold text-black">
+            Amount (USD) - Optional
+          </label>
+          <input
+            type="text"
+            value={amount}
+            onChange={handleInputChange}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+              }
+            }}
+            placeholder="Enter amount or leave blank"
+            className="w-full p-3 border border-surface-grey bg-white text-black placeholder:text-surface-grey-2 focus:outline-none focus:border-[#EA5817]"
+          />
+        </form>
+      </div>
+
+      <div className="relative lifted-button-container">
+        <LiftedButton onClick={handleBuy} className="" form="mtpelerin-form">
+          Buy with Mt Pelerin
+        </LiftedButton>
+      </div>
+    </div>
+  );
+}

--- a/src/app/bakery/components/Swap/MtPelerinBuy.tsx
+++ b/src/app/bakery/components/Swap/MtPelerinBuy.tsx
@@ -2,7 +2,7 @@
 
 import { ChangeEvent } from "react";
 import { Body, LiftedButton } from "@breadcoop/ui";
-import { buildMtPelerinUrl, hasMtPelerinKey } from "@/lib/mtPelerin";
+import { buildMtPelerinUrl } from "@/lib/mtPelerin";
 import { sanitizeInputValue } from "@/app/core/util/sanitizeInput";
 
 export function MtPelerinBuy({
@@ -37,39 +37,31 @@ export function MtPelerinBuy({
           <Body className="text-sm mb-3">
             Mt Pelerin is a Swiss fiat-to-crypto service that buys xDAI directly on Gnosis Chain. No ID is required for card purchases up to roughly 5,000 CHF/EUR/GBP, or bank transfers under CHF 100,000.
           </Body>
-          {hasMtPelerinKey ? (
-            <Body className="text-sm mb-3">
-              Insert the amount of xDAI you would like to purchase and bake into BREAD, then continue the process by clicking the buy button below.
-            </Body>
-          ) : (
-            <Body className="text-sm mb-3">
-              Clicking the buy button opens Mt Pelerin&apos;s site, where you choose the amount and enter the wallet address to receive your xDAI.
-            </Body>
-          )}
+          <Body className="text-sm mb-3">
+            Insert the amount of xDAI you would like to purchase and bake into BREAD, then continue the process by clicking the buy button below.
+          </Body>
           <Body className="text-sm mb-4">
             Your purchase completes on Mt Pelerin&apos;s site &mdash; once done, your xDAI should arrive in your wallet shortly.
           </Body>
         </div>
 
-        {hasMtPelerinKey && (
-          <form onSubmit={e => e.preventDefault()} id="mtpelerin-form" className="space-y-2">
-            <label className="text-sm font-bold text-black">
-              Amount (USD) - Optional
-            </label>
-            <input
-              type="text"
-              value={amount}
-              onChange={handleInputChange}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault();
-                }
-              }}
-              placeholder="Enter amount or leave blank"
-              className="w-full p-3 border border-surface-grey bg-white text-black placeholder:text-surface-grey-2 focus:outline-none focus:border-[#EA5817]"
-            />
-          </form>
-        )}
+        <form onSubmit={e => e.preventDefault()} id="mtpelerin-form" className="space-y-2">
+          <label className="text-sm font-bold text-black">
+            Amount (USD) - Optional
+          </label>
+          <input
+            type="text"
+            value={amount}
+            onChange={handleInputChange}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+              }
+            }}
+            placeholder="Enter amount or leave blank"
+            className="w-full p-3 border border-surface-grey bg-white text-black placeholder:text-surface-grey-2 focus:outline-none focus:border-[#EA5817]"
+          />
+        </form>
       </div>
 
       <div className="relative lifted-button-container">

--- a/src/app/bakery/components/Swap/MtPelerinBuy.tsx
+++ b/src/app/bakery/components/Swap/MtPelerinBuy.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent } from "react";
 import { Body, LiftedButton } from "@breadcoop/ui";
 import { buildMtPelerinUrl, hasMtPelerinKey } from "@/lib/mtPelerin";
 import { sanitizeInputValue } from "@/app/core/util/sanitizeInput";
+import { WalletAddressHint } from "./WalletAddressHint";
 
 export function MtPelerinBuy({
   amount,
@@ -56,7 +57,7 @@ export function MtPelerinBuy({
             </div>
           )}
           {!hasMtPelerinKey && recipientAddress && (
-            <WalletAddressHint address={recipientAddress} />
+            <WalletAddressHint address={recipientAddress} label="Your wallet address (for step 3):" />
           )}
         </div>
 
@@ -85,38 +86,6 @@ export function MtPelerinBuy({
         <LiftedButton onClick={handleBuy} className="" form={hasMtPelerinKey ? "mtpelerin-form" : undefined}>
           Buy with Mt Pelerin
         </LiftedButton>
-      </div>
-    </div>
-  );
-}
-
-function WalletAddressHint({ address }: { address: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(address);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Clipboard unavailable (e.g. insecure context) — user can select the text manually
-    }
-  };
-
-  return (
-    <div className="bg-paper-main p-3 mt-3">
-      <Body className="text-xs font-semibold text-surface-grey mb-1">
-        Your wallet address (for step 3):
-      </Body>
-      <div className="flex items-center gap-2">
-        <code className="text-xs text-surface-ink break-all">{address}</code>
-        <button
-          type="button"
-          onClick={handleCopy}
-          className="text-xs font-bold text-primary-orange hover:underline shrink-0"
-        >
-          {copied ? "Copied!" : "Copy"}
-        </button>
       </div>
     </div>
   );

--- a/src/app/bakery/components/Swap/NewSwap.tsx
+++ b/src/app/bakery/components/Swap/NewSwap.tsx
@@ -21,14 +21,13 @@ import { InsufficentBalance } from "./InsufficentBalance";
 // import { sleep } from "@/utils/sleep";
 import { Bridge } from "./Bridge";
 import { Buy } from "./Buy";
-import { useToast } from "@/app/core/context/ToastContext/ToastContext";
 import { TSwapMode } from "./interfaces";
 
 const notes: Record<TSwapState["mode"], string> = {
 	"BAKE": 'Baking adds new BREAD into circulation. You can redeem your BREAD through the "Burn" tab at any time',
 	"BURN": "When you Burn BREAD, you are no longer contributing to the Solidarity Fund, and all voting power will be removed.",
 	"BRIDGE": "This bridge is powered by LI.FI",
-	"BUY": "Clicking a buy button will open the selected provider's website where you can complete your purchase of xDAI to bake into BREAD.",
+	"BUY": "Clicking a buy button will open the selected provider's website. Follow the steps shown for your provider to end up with xDAI on Gnosis, ready to bake into BREAD.",
 };
 
 const validModes: TSwapMode[] = ["BAKE", "BRIDGE", "BURN", "BUY"];
@@ -43,8 +42,6 @@ const NewSwap = () => {
 		mode: validModes.includes(tabParams) ? tabParams : "BAKE",
 		value: "",
 	});
-	const { toastDispatch } = useToast();
-
 	useEffect(() => {
 		const params = searchParams.get("tab") as unknown as TSwapMode;
 		if (validModes.includes(params)) {
@@ -54,24 +51,6 @@ const NewSwap = () => {
 			});
 		}
 	}, [searchParams.get("tab"), searchParams.get("v")]);
-
-	// Handle Peer callback
-	useEffect(() => {
-		if (searchParams.get("peer") === "success") {
-			toastDispatch({
-				type: "CUSTOM",
-				payload: {
-					variant: "success",
-					message:
-						"Purchase completed! Your xDAI should arrive shortly.",
-				},
-			});
-			// Clean up URL
-			// window.history.replaceState({}, "", "/bakery");
-			window.history.replaceState({}, "", "/");
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [searchParams.get("peer")]);
 
 	if (
 		user.status === "CONNECTED" &&

--- a/src/app/bakery/components/Swap/NewSwap.tsx
+++ b/src/app/bakery/components/Swap/NewSwap.tsx
@@ -22,14 +22,13 @@ import { InsufficentBalance } from "./InsufficentBalance";
 import { Bridge } from "./Bridge";
 import { Buy } from "./Buy";
 import { useToast } from "@/app/core/context/ToastContext/ToastContext";
-import { useStrictMobile } from "@/hooks/use-is-device";
 import { TSwapMode } from "./interfaces";
 
 const notes: Record<TSwapState["mode"], string> = {
 	"BAKE": 'Baking adds new BREAD into circulation. You can redeem your BREAD through the "Burn" tab at any time',
 	"BURN": "When you Burn BREAD, you are no longer contributing to the Solidarity Fund, and all voting power will be removed.",
 	"BRIDGE": "This bridge is powered by LI.FI",
-	"BUY": "Clicking the button will open the Peer website where you can complete your purchase of xDAI to bake into BREAD.",
+	"BUY": "Clicking a buy button will open the selected provider's website where you can complete your purchase of xDAI to bake into BREAD.",
 };
 
 const validModes: TSwapMode[] = ["BAKE", "BRIDGE", "BURN", "BUY"];
@@ -45,7 +44,6 @@ const NewSwap = () => {
 		value: "",
 	});
 	const { toastDispatch } = useToast();
-	const { isMobile } = useStrictMobile();
 
 	useEffect(() => {
 		const params = searchParams.get("tab") as unknown as TSwapMode;
@@ -252,12 +250,10 @@ const NewSwap = () => {
 					)}
 				</div>
 			)}
-			{!(swapState.mode === "BUY" && isMobile) && (
-				<Body className="text-surface-grey text-sm mt-1">
-					<span className="font-bold">Note</span>:{" "}
-					{notes[swapState.mode]}
-				</Body>
-			)}
+			<Body className="text-surface-grey text-sm mt-1">
+				<span className="font-bold">Note</span>:{" "}
+				{notes[swapState.mode]}
+			</Body>
 		</div>
 	);
 };

--- a/src/app/bakery/components/Swap/PeerBuy.tsx
+++ b/src/app/bakery/components/Swap/PeerBuy.tsx
@@ -22,9 +22,9 @@ export function PeerBuy() {
           <div className="mb-3">
             <Body className="text-sm mb-2 font-bold text-surface-ink">How it works:</Body>
             <ol className="text-sm list-decimal list-inside space-y-1">
-              <li>Click the button below to open Peer, then connect a wallet or log in</li>
-              <li>On the Buy tab, choose your amount and payment app &mdash; you&apos;ll receive USDC (pick Base as the network)</li>
-              <li>Pay through your payment app and wait a moment for verification</li>
+              <li>Click the button below to open Peer&apos;s trade page, then log in with a wallet or social account</li>
+              <li>Buy USDC &mdash; choose your amount, currency, and payment app (pick Base as the network)</li>
+              <li>Complete the payment in your payment app and wait for verification</li>
               <li>Come back and use our Bridge tab to swap the USDC into xDAI on Gnosis, ready to bake into BREAD</li>
             </ol>
           </div>

--- a/src/app/bakery/components/Swap/PeerBuy.tsx
+++ b/src/app/bakery/components/Swap/PeerBuy.tsx
@@ -49,8 +49,28 @@ function PeerInApp({ onramp }: { onramp: ReturnType<typeof usePeerOnramp> }) {
   const platform = PEER_PLATFORMS.find((p) => p.key === platformKey)!;
   const { status, error, quote } = onramp;
 
-  const handleAmount = (e: ChangeEvent<HTMLInputElement>) =>
+  // Clear any stale quote/error when the inputs change.
+  const clearQuoteState = () => {
+    if (status === "quote_ready" || status === "error") onramp.reset();
+  };
+
+  const handlePlatform = (key: string) => {
+    setPlatformKey(key);
+    const next = PEER_PLATFORMS.find((p) => p.key === key)!;
+    // Venmo is USD-only etc. — clamp the currency to what this platform supports.
+    if (!next.currencies.includes(fiat)) setFiat(next.currencies[0]);
+    clearQuoteState();
+  };
+
+  const handleCurrency = (v: string) => {
+    setFiat(v as PeerFiat);
+    clearQuoteState();
+  };
+
+  const handleAmount = (e: ChangeEvent<HTMLInputElement>) => {
     setAmount(sanitizeInputValue(e.target.value));
+    clearQuoteState();
+  };
 
   const onContinue = () => onramp.fetchQuote({ platform, fiat, amount });
   const onConfirm = () => onramp.purchase({ platform, fiat });
@@ -113,13 +133,16 @@ function PeerInApp({ onramp }: { onramp: ReturnType<typeof usePeerOnramp> }) {
         label="Pay with"
         options={PEER_PLATFORMS.map((p) => ({ key: p.key, label: p.label }))}
         value={platformKey}
-        onChange={setPlatformKey}
+        onChange={handlePlatform}
       />
       <Selector
         label="Currency"
-        options={PEER_FIATS.map((f) => ({ key: f.code, label: f.code }))}
+        options={PEER_FIATS.filter((f) => platform.currencies.includes(f.code)).map((f) => ({
+          key: f.code,
+          label: f.code,
+        }))}
         value={fiat}
-        onChange={(v) => setFiat(v as PeerFiat)}
+        onChange={handleCurrency}
       />
 
       <div className="space-y-2">

--- a/src/app/bakery/components/Swap/PeerBuy.tsx
+++ b/src/app/bakery/components/Swap/PeerBuy.tsx
@@ -2,8 +2,9 @@
 
 import { Body, LiftedButton } from "@breadcoop/ui";
 import { buildPeerUrl } from "@/lib/peer";
+import { WalletAddressHint } from "./WalletAddressHint";
 
-export function PeerBuy() {
+export function PeerBuy({ recipientAddress }: { recipientAddress?: string }) {
   const handleBuy = () => {
     window.open(buildPeerUrl(), "_blank");
   };
@@ -17,20 +18,24 @@ export function PeerBuy() {
             <Body className="text-base font-bold text-surface-ink">Buy with Peer</Body>
           </div>
           <Body className="text-sm mb-3">
-            Peer is a peer-to-peer service where you can buy crypto without KYC using payment apps like Venmo, Revolut, Wise, Cash App, Zelle, and N26.
+            Peer is a peer-to-peer marketplace where you buy crypto without KYC directly from other people, paying through apps like Venmo, Revolut, Wise, Cash App, Zelle, and N26.
           </Body>
           <div className="mb-3">
             <Body className="text-sm mb-2 font-bold text-surface-ink">How it works:</Body>
             <ol className="text-sm list-decimal list-inside space-y-1">
-              <li>Click the button below to open Peer&apos;s trade page, then log in with a wallet or social account</li>
-              <li>Buy USDC &mdash; choose your amount, currency, and payment app (pick Base as the network)</li>
-              <li>Complete the payment in your payment app and wait for verification</li>
+              <li>Click the button below to open Peer&apos;s trade page and log in with a wallet or social account</li>
+              <li>Select the currency you&apos;re paying with and your payment app to see the available offers</li>
+              <li>Pick an offer from the list to buy USDC (choose Base as the network)</li>
+              <li>Pay through your payment app &mdash; Peer verifies the payment automatically and releases the USDC to your wallet</li>
               <li>Come back and use our Bridge tab to swap the USDC into xDAI on Gnosis, ready to bake into BREAD</li>
             </ol>
           </div>
           <Body className="text-sm mb-4">
             <LearnMoreLink />
           </Body>
+          {recipientAddress && (
+            <WalletAddressHint address={recipientAddress} label="Your wallet address:" />
+          )}
         </div>
       </div>
 

--- a/src/app/bakery/components/Swap/PeerBuy.tsx
+++ b/src/app/bakery/components/Swap/PeerBuy.tsx
@@ -1,45 +1,266 @@
 "use client";
 
+import { ChangeEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import clsx from "clsx";
 import { Body, LiftedButton } from "@breadcoop/ui";
 import { buildPeerUrl } from "@/lib/peer";
+import { PEER_FIATS, PEER_PLATFORMS, type PeerFiat } from "@/lib/peerSdk";
+import { sanitizeInputValue } from "@/app/core/util/sanitizeInput";
+import { useStrictMobile } from "@/hooks/use-is-device";
+import { usePeerOnramp } from "./usePeerOnramp";
 import { WalletAddressHint } from "./WalletAddressHint";
 
 export function PeerBuy({ recipientAddress }: { recipientAddress?: string }) {
-  const handleBuy = () => {
-    window.open(buildPeerUrl(), "_blank");
-  };
+  const { isMobile } = useStrictMobile();
+  const onramp = usePeerOnramp();
+
+  // The in-app SDK flow needs a desktop browser (PeerAuth extension) and a
+  // connected wallet. Otherwise fall back to the guided link-out.
+  const canUseInApp = !isMobile && onramp.isConnected;
 
   return (
     <div className="space-y-4">
       <div className="bg-paper-1 p-5">
-        <div className="text-surface-grey-2 text-sm mb-4">
-          <div className="flex items-center gap-3 mb-4">
-            <img src="https://www.peer.xyz/logo192.png" alt="Peer" className="h-10 w-10" />
-            <Body className="text-base font-bold text-surface-ink">Buy with Peer</Body>
-          </div>
-          <Body className="text-sm mb-3">
-            Peer is a peer-to-peer marketplace where you buy crypto without KYC directly from other people, paying through apps like Venmo, Revolut, Wise, Cash App, and Zelle.
-          </Body>
-          <div className="mb-3">
-            <Body className="text-sm mb-2 font-bold text-surface-ink">How it works:</Body>
-            <ol className="text-sm list-decimal list-inside space-y-1">
-              <li>Click the button below to open Peer&apos;s trade page and log in with a wallet or social account</li>
-              <li>Select the currency you&apos;re paying with and your payment app to see the available offers</li>
-              <li>Pick an offer from the list to buy USDC (delivered on Base)</li>
-              <li>Pay through your payment app &mdash; Peer verifies the payment automatically and releases the USDC to your wallet</li>
-              <li>Come back and use our Bridge tab to move the USDC from Base into xDAI on Gnosis, ready to bake into BREAD</li>
-            </ol>
-          </div>
-          {recipientAddress && (
-            <WalletAddressHint address={recipientAddress} label="Your wallet address:" />
-          )}
+        <div className="flex items-center gap-3 mb-4">
+          <img src="https://www.peer.xyz/logo192.png" alt="Peer" className="h-10 w-10" />
+          <Body className="text-base font-bold text-surface-ink">Buy with Peer</Body>
         </div>
+        {canUseInApp ? (
+          <PeerInApp onramp={onramp} />
+        ) : (
+          <PeerLinkFallback recipientAddress={recipientAddress} isMobile={isMobile} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* In-app SDK flow                                                     */
+/* ------------------------------------------------------------------ */
+
+function PeerInApp({ onramp }: { onramp: ReturnType<typeof usePeerOnramp> }) {
+  const router = useRouter();
+  const [platformKey, setPlatformKey] = useState(PEER_PLATFORMS[0].key);
+  const [fiat, setFiat] = useState<PeerFiat>("USD");
+  const [amount, setAmount] = useState("");
+
+  const platform = PEER_PLATFORMS.find((p) => p.key === platformKey)!;
+  const { status, error, quote } = onramp;
+
+  const handleAmount = (e: ChangeEvent<HTMLInputElement>) =>
+    setAmount(sanitizeInputValue(e.target.value));
+
+  const onContinue = () => onramp.fetchQuote({ platform, fiat, amount });
+  const onConfirm = () => onramp.purchase({ platform, fiat });
+
+  // Status screens after the form.
+  if (status === "success") {
+    return (
+      <div className="space-y-3">
+        <Body className="text-sm text-surface-ink font-bold">Payment verified!</Body>
+        <Body className="text-sm text-surface-grey-2">
+          Your USDC is on its way to your wallet on Base. Bridge it to xDAI on Gnosis to bake into BREAD.
+        </Body>
+        <div className="lifted-button-container">
+          <LiftedButton onClick={() => router.push("/?tab=BRIDGE")}>
+            Continue to Bridge →
+          </LiftedButton>
+        </div>
+        <button type="button" onClick={onramp.reset} className="text-xs text-surface-grey hover:underline">
+          Buy again
+        </button>
+      </div>
+    );
+  }
+
+  if (status === "need_extension") {
+    return (
+      <StatusBlock
+        title="Install the PeerAuth extension"
+        body="Peer uses a browser extension to verify your payment privately. Install or connect it, then try again."
+        onRetry={onConfirm}
+        onCancel={onramp.reset}
+      />
+    );
+  }
+
+  if (status === "signalling") {
+    return <StatusBlock title="Confirm in your wallet" body="Approve the transaction to reserve your offer on Base." />;
+  }
+
+  if (status === "awaiting_payment") {
+    return (
+      <StatusBlock
+        title={`Pay with ${platform.label}`}
+        body={`A ${platform.label} tab has opened. Complete your payment there — we'll verify it automatically. Keep this tab open.`}
+      />
+    );
+  }
+
+  if (status === "verifying") {
+    return <StatusBlock title="Verifying your payment" body="This usually takes a few seconds…" />;
+  }
+
+  return (
+    <div className="space-y-4">
+      <Body className="text-sm text-surface-grey-2">
+        Buy USDC without KYC directly from another person, paying through your payment app. You&apos;ll receive USDC on Base — bridge it to xDAI on the next step.
+      </Body>
+
+      <Selector
+        label="Pay with"
+        options={PEER_PLATFORMS.map((p) => ({ key: p.key, label: p.label }))}
+        value={platformKey}
+        onChange={setPlatformKey}
+      />
+      <Selector
+        label="Currency"
+        options={PEER_FIATS.map((f) => ({ key: f.code, label: f.code }))}
+        value={fiat}
+        onChange={(v) => setFiat(v as PeerFiat)}
+      />
+
+      <div className="space-y-2">
+        <label className="text-sm font-bold text-black">Amount ({fiat})</label>
+        <input
+          type="text"
+          value={amount}
+          onChange={handleAmount}
+          placeholder="Enter amount"
+          className="w-full p-3 border border-surface-grey bg-white text-black placeholder:text-surface-grey-2 focus:outline-none focus:border-[#EA5817]"
+        />
       </div>
 
+      {status === "quote_ready" && quote && (
+        <div className="bg-paper-main p-3 text-sm space-y-1">
+          <div className="flex justify-between">
+            <span className="text-surface-grey-2">You pay</span>
+            <span className="text-surface-ink font-bold">{quote.fiatAmountFormatted} {fiat}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-surface-grey-2">You receive</span>
+            <span className="text-surface-ink font-bold">{quote.tokenAmountFormatted} USDC</span>
+          </div>
+        </div>
+      )}
+
+      {error && <Body className="text-sm text-[#e00900]">{error}</Body>}
+
+      <div className="lifted-button-container">
+        {status === "quote_ready" ? (
+          <LiftedButton onClick={onConfirm}>Confirm &amp; pay</LiftedButton>
+        ) : (
+          <LiftedButton onClick={onContinue} disabled={status === "quoting" || !amount}>
+            {status === "quoting" ? "Getting best offer…" : "Continue"}
+          </LiftedButton>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Selector({
+  label,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  options: { key: string; label: string }[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <fieldset className="space-y-2">
+      <legend className="text-sm font-bold text-black mb-2">{label}</legend>
+      <div className="grid grid-cols-3 gap-2">
+        {options.map((o) => (
+          <button
+            key={o.key}
+            type="button"
+            aria-pressed={value === o.key}
+            onClick={() => onChange(o.key)}
+            className={clsx(
+              "font-bold py-3 px-2 border transition-colors",
+              value === o.key
+                ? "border-primary-orange text-primary-orange bg-primary-orange/10"
+                : "border-surface-grey text-surface-grey bg-paper-main bg-opacity-30",
+            )}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+function StatusBlock({
+  title,
+  body,
+  onRetry,
+  onCancel,
+}: {
+  title: string;
+  body: string;
+  onRetry?: () => void;
+  onCancel?: () => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <Body className="text-sm font-bold text-surface-ink">{title}</Body>
+      <Body className="text-sm text-surface-grey-2">{body}</Body>
+      {(onRetry || onCancel) && (
+        <div className="flex items-center gap-3">
+          {onRetry && (
+            <button type="button" onClick={onRetry} className="text-sm font-bold text-primary-orange hover:underline">
+              Try again
+            </button>
+          )}
+          {onCancel && (
+            <button type="button" onClick={onCancel} className="text-sm text-surface-grey hover:underline">
+              Cancel
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Link-out fallback (mobile / no wallet)                              */
+/* ------------------------------------------------------------------ */
+
+function PeerLinkFallback({ recipientAddress, isMobile }: { recipientAddress?: string; isMobile: boolean }) {
+  const handleBuy = () => window.open(buildPeerUrl(), "_blank");
+  return (
+    <div className="space-y-4">
+      <div className="text-surface-grey-2 text-sm">
+        <Body className="text-sm mb-3">
+          Peer is a peer-to-peer marketplace where you buy crypto without KYC directly from other people, paying through apps like Venmo, Revolut, Wise, Cash App, and Zelle.
+        </Body>
+        {isMobile && (
+          <Body className="text-sm mb-3 text-surface-grey">
+            The in-app buy flow needs a desktop browser. On mobile, continue on Peer&apos;s site instead.
+          </Body>
+        )}
+        <div className="mb-3">
+          <Body className="text-sm mb-2 font-bold text-surface-ink">How it works:</Body>
+          <ol className="text-sm list-decimal list-inside space-y-1">
+            <li>Click the button below to open Peer&apos;s trade page and log in</li>
+            <li>Select the currency you&apos;re paying with and your payment app to see offers</li>
+            <li>Pick an offer to buy USDC (delivered on Base)</li>
+            <li>Pay through your payment app — Peer verifies and releases the USDC to your wallet</li>
+            <li>Come back and use our Bridge tab to move the USDC from Base into xDAI on Gnosis</li>
+          </ol>
+        </div>
+        {recipientAddress && <WalletAddressHint address={recipientAddress} label="Your wallet address:" />}
+      </div>
       <div className="relative lifted-button-container">
-        <LiftedButton onClick={handleBuy} className="">
-          Buy with Peer
-        </LiftedButton>
+        <LiftedButton onClick={handleBuy}>Buy with Peer</LiftedButton>
       </div>
     </div>
   );

--- a/src/app/bakery/components/Swap/PeerBuy.tsx
+++ b/src/app/bakery/components/Swap/PeerBuy.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { ChangeEvent } from "react";
+import { Body, LiftedButton } from "@breadcoop/ui";
+import { buildPeerUrl } from "@/lib/peer";
+import { sanitizeInputValue } from "@/app/core/util/sanitizeInput";
+
+export function PeerBuy({
+  amount,
+  onAmountChange,
+  recipientAddress,
+}: {
+  amount: string;
+  onAmountChange: (amount: string) => void;
+  recipientAddress?: string;
+}) {
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onAmountChange(sanitizeInputValue(event.target.value));
+  };
+
+  const handleBuy = () => {
+    const url = buildPeerUrl({
+      ...(amount && { inputAmount: amount }),
+      ...(recipientAddress && { recipientAddress }),
+    });
+    window.open(url, "_blank");
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-paper-1 p-5">
+        <div className="text-surface-grey-2 text-sm mb-4">
+          <div className="flex items-center gap-3 mb-4">
+            <img src="https://www.peer.xyz/logo192.png" alt="Peer" className="h-10 w-10" />
+            <Body className="text-base font-bold text-surface-ink">Buy with Peer</Body>
+          </div>
+          <Body className="text-sm mb-3">
+            Peer is a service where you can buy crypto without KYC using various neobanking applications.
+          </Body>
+          <Body className="text-sm mb-3">
+            Insert the amount of xDAI you would like to purchase and bake into BREAD, then continue the process by clicking the buy button below.
+          </Body>
+          <Body className="text-sm mb-4">
+            <LearnMoreLink />
+          </Body>
+          <Body className="text-sm flex items-center gap-2 mt-4">
+            <span className="text-xs font-semibold text-surface-grey">Supported apps:</span>
+            <span className="text-xs text-surface-grey-2">Venmo, Revolut, Wise, Cash App, Zelle, N26, and more</span>
+          </Body>
+        </div>
+
+        <form onSubmit={e => e.preventDefault()} id="peer-form" className="space-y-2">
+          <label className="text-sm font-bold text-black">
+            Amount (USD) - Optional
+          </label>
+          <input
+            type="text"
+            value={amount}
+            onChange={handleInputChange}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+              }
+            }}
+            placeholder="Enter amount or leave blank"
+            className="w-full p-3 border border-surface-grey bg-white text-black placeholder:text-surface-grey-2 focus:outline-none focus:border-[#EA5817]"
+          />
+        </form>
+      </div>
+
+      <div className="relative lifted-button-container">
+        <LiftedButton onClick={handleBuy} className="" form="peer-form">
+          Buy with Peer
+        </LiftedButton>
+      </div>
+    </div>
+  );
+}
+
+function LearnMoreLink() {
+	return (
+		<a
+			href="https://docs.peer.xyz/guides/for-buyers/complete-guide-to-onboarding"
+			className="text-primary-orange hover:underline"
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			Learn more about the process →
+		</a>
+	);
+}

--- a/src/app/bakery/components/Swap/PeerBuy.tsx
+++ b/src/app/bakery/components/Swap/PeerBuy.tsx
@@ -25,9 +25,9 @@ export function PeerBuy({ recipientAddress }: { recipientAddress?: string }) {
             <ol className="text-sm list-decimal list-inside space-y-1">
               <li>Click the button below to open Peer&apos;s trade page and log in with a wallet or social account</li>
               <li>Select the currency you&apos;re paying with and your payment app to see the available offers</li>
-              <li>Pick an offer from the list to buy USDC (choose Base as the network)</li>
+              <li>Pick an offer from the list to buy USDC (delivered on Base)</li>
               <li>Pay through your payment app &mdash; Peer verifies the payment automatically and releases the USDC to your wallet</li>
-              <li>Come back and use our Bridge tab to swap the USDC into xDAI on Gnosis, ready to bake into BREAD</li>
+              <li>Come back and use our Bridge tab to move the USDC from Base into xDAI on Gnosis, ready to bake into BREAD</li>
             </ol>
           </div>
           <Body className="text-sm mb-4">

--- a/src/app/bakery/components/Swap/PeerBuy.tsx
+++ b/src/app/bakery/components/Swap/PeerBuy.tsx
@@ -18,7 +18,7 @@ export function PeerBuy({ recipientAddress }: { recipientAddress?: string }) {
             <Body className="text-base font-bold text-surface-ink">Buy with Peer</Body>
           </div>
           <Body className="text-sm mb-3">
-            Peer is a peer-to-peer marketplace where you buy crypto without KYC directly from other people, paying through apps like Venmo, Revolut, Wise, Cash App, Zelle, and N26.
+            Peer is a peer-to-peer marketplace where you buy crypto without KYC directly from other people, paying through apps like Venmo, Revolut, Wise, Cash App, and Zelle.
           </Body>
           <div className="mb-3">
             <Body className="text-sm mb-2 font-bold text-surface-ink">How it works:</Body>
@@ -30,9 +30,6 @@ export function PeerBuy({ recipientAddress }: { recipientAddress?: string }) {
               <li>Come back and use our Bridge tab to move the USDC from Base into xDAI on Gnosis, ready to bake into BREAD</li>
             </ol>
           </div>
-          <Body className="text-sm mb-4">
-            <LearnMoreLink />
-          </Body>
           {recipientAddress && (
             <WalletAddressHint address={recipientAddress} label="Your wallet address:" />
           )}
@@ -46,17 +43,4 @@ export function PeerBuy({ recipientAddress }: { recipientAddress?: string }) {
       </div>
     </div>
   );
-}
-
-function LearnMoreLink() {
-	return (
-		<a
-			href="https://docs.peer.xyz/guides/for-buyers/complete-guide-to-onboarding"
-			className="text-primary-orange hover:underline"
-			target="_blank"
-			rel="noopener noreferrer"
-		>
-			Learn more about the process →
-		</a>
-	);
 }

--- a/src/app/bakery/components/Swap/PeerBuy.tsx
+++ b/src/app/bakery/components/Swap/PeerBuy.tsx
@@ -1,29 +1,11 @@
 "use client";
 
-import { ChangeEvent } from "react";
 import { Body, LiftedButton } from "@breadcoop/ui";
 import { buildPeerUrl } from "@/lib/peer";
-import { sanitizeInputValue } from "@/app/core/util/sanitizeInput";
 
-export function PeerBuy({
-  amount,
-  onAmountChange,
-  recipientAddress,
-}: {
-  amount: string;
-  onAmountChange: (amount: string) => void;
-  recipientAddress?: string;
-}) {
-  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
-    onAmountChange(sanitizeInputValue(event.target.value));
-  };
-
+export function PeerBuy() {
   const handleBuy = () => {
-    const url = buildPeerUrl({
-      ...(amount && { inputAmount: amount }),
-      ...(recipientAddress && { recipientAddress }),
-    });
-    window.open(url, "_blank");
+    window.open(buildPeerUrl(), "_blank");
   };
 
   return (
@@ -35,41 +17,25 @@ export function PeerBuy({
             <Body className="text-base font-bold text-surface-ink">Buy with Peer</Body>
           </div>
           <Body className="text-sm mb-3">
-            Peer is a service where you can buy crypto without KYC using various neobanking applications.
+            Peer is a peer-to-peer service where you can buy crypto without KYC using payment apps like Venmo, Revolut, Wise, Cash App, Zelle, and N26.
           </Body>
-          <Body className="text-sm mb-3">
-            Insert the amount of xDAI you would like to purchase and bake into BREAD, then continue the process by clicking the buy button below.
-          </Body>
+          <div className="mb-3">
+            <Body className="text-sm mb-2 font-bold text-surface-ink">How it works:</Body>
+            <ol className="text-sm list-decimal list-inside space-y-1">
+              <li>Click the button below to open Peer, then connect a wallet or log in</li>
+              <li>On the Buy tab, choose your amount and payment app &mdash; you&apos;ll receive USDC (pick Base as the network)</li>
+              <li>Pay through your payment app and wait a moment for verification</li>
+              <li>Come back and use our Bridge tab to swap the USDC into xDAI on Gnosis, ready to bake into BREAD</li>
+            </ol>
+          </div>
           <Body className="text-sm mb-4">
             <LearnMoreLink />
           </Body>
-          <Body className="text-sm flex items-center gap-2 mt-4">
-            <span className="text-xs font-semibold text-surface-grey">Supported apps:</span>
-            <span className="text-xs text-surface-grey-2">Venmo, Revolut, Wise, Cash App, Zelle, N26, and more</span>
-          </Body>
         </div>
-
-        <form onSubmit={e => e.preventDefault()} id="peer-form" className="space-y-2">
-          <label className="text-sm font-bold text-black">
-            Amount (USD) - Optional
-          </label>
-          <input
-            type="text"
-            value={amount}
-            onChange={handleInputChange}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-              }
-            }}
-            placeholder="Enter amount or leave blank"
-            className="w-full p-3 border border-surface-grey bg-white text-black placeholder:text-surface-grey-2 focus:outline-none focus:border-[#EA5817]"
-          />
-        </form>
       </div>
 
       <div className="relative lifted-button-container">
-        <LiftedButton onClick={handleBuy} className="" form="peer-form">
+        <LiftedButton onClick={handleBuy} className="">
           Buy with Peer
         </LiftedButton>
       </div>

--- a/src/app/bakery/components/Swap/ProviderPicker.tsx
+++ b/src/app/bakery/components/Swap/ProviderPicker.tsx
@@ -20,7 +20,7 @@ export function ProviderPicker({
       />
       <ProviderOption
         name="Mt Pelerin"
-        logoSrc="https://www.mtpelerin.com/favicon.ico"
+        logoSrc="https://www.mtpelerin.com/icons/android-chrome-192x192.png"
         isSelected={provider === "MT_PELERIN"}
         onSelect={() => setProvider("MT_PELERIN")}
       />

--- a/src/app/bakery/components/Swap/ProviderPicker.tsx
+++ b/src/app/bakery/components/Swap/ProviderPicker.tsx
@@ -13,16 +13,16 @@ export function ProviderPicker({
     <fieldset className="grid gap-4 grid-cols-2 mb-4">
       <legend className="sr-only">Choose a payment provider</legend>
       <ProviderOption
-        name="Peer"
-        logoSrc="https://www.peer.xyz/logo192.png"
-        isSelected={provider === "PEER"}
-        onSelect={() => setProvider("PEER")}
-      />
-      <ProviderOption
         name="Mt Pelerin"
         logoSrc="https://www.mtpelerin.com/icons/android-chrome-192x192.png"
         isSelected={provider === "MT_PELERIN"}
         onSelect={() => setProvider("MT_PELERIN")}
+      />
+      <ProviderOption
+        name="Peer"
+        logoSrc="https://www.peer.xyz/logo192.png"
+        isSelected={provider === "PEER"}
+        onSelect={() => setProvider("PEER")}
       />
     </fieldset>
   );

--- a/src/app/bakery/components/Swap/ProviderPicker.tsx
+++ b/src/app/bakery/components/Swap/ProviderPicker.tsx
@@ -1,0 +1,62 @@
+import clsx from "clsx";
+import { Body } from "@breadcoop/ui";
+import { TBuyProvider } from "./interfaces";
+
+export function ProviderPicker({
+  provider,
+  setProvider,
+}: {
+  provider: TBuyProvider;
+  setProvider: (provider: TBuyProvider) => void;
+}) {
+  return (
+    <fieldset className="grid gap-4 grid-cols-2 mb-4">
+      <legend className="sr-only">Choose a payment provider</legend>
+      <ProviderOption
+        name="Peer"
+        logoSrc="https://www.peer.xyz/logo192.png"
+        isSelected={provider === "PEER"}
+        onSelect={() => setProvider("PEER")}
+      />
+      <ProviderOption
+        name="Mt Pelerin"
+        logoSrc="https://www.mtpelerin.com/favicon.ico"
+        isSelected={provider === "MT_PELERIN"}
+        onSelect={() => setProvider("MT_PELERIN")}
+      />
+    </fieldset>
+  );
+}
+
+function ProviderOption({
+  name,
+  logoSrc,
+  isSelected,
+  onSelect,
+}: {
+  name: string;
+  logoSrc: string;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <div className="grid">
+      <button
+        type="button"
+        onClick={onSelect}
+        aria-pressed={isSelected}
+        className={clsx(
+          "font-bold py-3 px-6 flex items-center justify-center cursor-pointer transition-colors border",
+          isSelected
+            ? "border-primary-orange text-primary-orange bg-primary-orange/10"
+            : "border-transparent text-surface-grey bg-paper-main bg-opacity-30"
+        )}
+      >
+        <Body className="flex gap-2.5 items-center justify-center">
+          <img src={logoSrc} alt="" className="size-6" />
+          {name}
+        </Body>
+      </button>
+    </div>
+  );
+}

--- a/src/app/bakery/components/Swap/WalletAddressHint.tsx
+++ b/src/app/bakery/components/Swap/WalletAddressHint.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { Body } from "@breadcoop/ui";
+
+export function WalletAddressHint({ address, label }: { address: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable (e.g. insecure context) — user can select the text manually
+    }
+  };
+
+  return (
+    <div className="bg-paper-main p-3 mt-3">
+      <Body className="text-xs font-semibold text-surface-grey mb-1">
+        {label}
+      </Body>
+      <div className="flex items-center gap-2">
+        <code className="text-xs text-surface-ink break-all">{address}</code>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="text-xs font-bold text-primary-orange hover:underline shrink-0"
+        >
+          {copied ? "Copied!" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/bakery/components/Swap/interfaces.ts
+++ b/src/app/bakery/components/Swap/interfaces.ts
@@ -1,1 +1,3 @@
 export type TSwapMode = "BAKE" | "BURN" | "BRIDGE" | "BUY";
+
+export type TBuyProvider = "PEER" | "MT_PELERIN";

--- a/src/app/bakery/components/Swap/usePeerOnramp.ts
+++ b/src/app/bakery/components/Swap/usePeerOnramp.ts
@@ -14,8 +14,9 @@
  * isolated and commented below.
  */
 
-import { useCallback, useMemo, useRef, useState } from "react";
-import { useAccount, usePublicClient, useSwitchChain, useWalletClient } from "wagmi";
+import { useCallback, useRef, useState } from "react";
+import { useAccount, useConfig, usePublicClient, useSwitchChain, useWalletClient } from "wagmi";
+import { getWalletClient } from "@wagmi/core";
 import { parseEventLogs, type Abi } from "viem";
 import type {
   BuyerTeePaymentProofInput,
@@ -104,10 +105,13 @@ function buildProof(
 }
 
 export function usePeerOnramp() {
-  const { address } = useAccount();
-  const { data: walletClient } = useWalletClient({ chainId: PEER_CHAIN_ID });
+  const { address, isConnected: accountConnected } = useAccount();
+  // Current-chain wallet client (present whenever connected — the wallet is
+  // usually on Gnosis). A Base-bound client is acquired lazily at purchase time.
+  const { data: walletClient } = useWalletClient();
   const publicClient = usePublicClient({ chainId: PEER_CHAIN_ID });
   const { switchChainAsync } = useSwitchChain();
+  const config = useConfig();
 
   const [status, setStatus] = useState<PeerOnrampStatus>("idle");
   const [error, setError] = useState<string | null>(null);
@@ -177,12 +181,13 @@ export function usePeerOnramp() {
       }
 
       try {
-        // Ensure the wallet is on Base for the on-chain steps.
+        // Ensure the wallet is on Base, then get a Base-bound wallet client for
+        // the on-chain steps (the connected wallet is usually on Gnosis).
         if (walletClient.chain?.id !== PEER_CHAIN_ID) {
           await switchChainAsync({ chainId: PEER_CHAIN_ID });
         }
-
-        const client = createPeerClient(walletClient);
+        const baseWalletClient = await getWalletClient(config, { chainId: PEER_CHAIN_ID });
+        const client = createPeerClient(baseWalletClient);
 
         // --- Step 2: signal intent (on-chain) ---
         setStatus("signalling");
@@ -259,10 +264,10 @@ export function usePeerOnramp() {
         fail(e instanceof Error ? e.message : "Purchase failed");
       }
     },
-    [walletClient, address, publicClient, quote, switchChainAsync, fail],
+    [walletClient, address, publicClient, quote, switchChainAsync, config, fail],
   );
 
-  const isConnected = useMemo(() => Boolean(address && walletClient), [address, walletClient]);
+  const isConnected = Boolean(address && accountConnected);
 
   return { status, error, quote, isConnected, fetchQuote, purchase, reset };
 }

--- a/src/app/bakery/components/Swap/usePeerOnramp.ts
+++ b/src/app/bakery/components/Swap/usePeerOnramp.ts
@@ -53,6 +53,9 @@ export type PeerOnrampParams = {
   amount: string;
 };
 
+const NO_OFFERS_MESSAGE =
+  "No offers available right now for this amount and payment method. Try a different amount, currency, or payment app.";
+
 function isBuyerTeeParams(value: unknown): value is Record<string, string | number | boolean> {
   return (
     typeof value === "object" &&
@@ -158,14 +161,16 @@ export function usePeerOnramp() {
         });
         const best = res.responseObject?.quotes?.[0] ?? null;
         if (!best) {
-          fail("No offers available for that amount and payment method");
+          fail(NO_OFFERS_MESSAGE);
           return null;
         }
         setQuote(best);
         setStatus("quote_ready");
         return best;
       } catch (e) {
-        fail(e instanceof Error ? e.message : "Failed to get a quote");
+        const msg = e instanceof Error ? e.message : "Failed to get a quote";
+        // The SDK throws "No quotes found" when no seller liquidity matches.
+        fail(/quote/i.test(msg) ? NO_OFFERS_MESSAGE : msg);
         return null;
       }
     },

--- a/src/app/bakery/components/Swap/usePeerOnramp.ts
+++ b/src/app/bakery/components/Swap/usePeerOnramp.ts
@@ -1,0 +1,295 @@
+"use client";
+
+/**
+ * State machine for the in-app Peer (ZKP2P) Buyer TEE onramp.
+ *
+ * Flow: getQuote → signalIntent (on-chain, Base) → ensure extension → authenticate
+ * (extension opens the payment-provider tab, user pays, extension captures metadata)
+ * → fulfillIntent (posts to Buyer TEE, on-chain fulfillment) → USDC on Base.
+ *
+ * NEEDS-REAL-TEST: this was written against the SDK's published types + Peer's agent
+ * guide but could not be runtime-tested in the sandbox. The two spots most likely to
+ * need adjustment after a real wallet+extension run are (1) extracting `intentHash`
+ * from the signalIntent receipt and (2) the exact payment-row matching. Both are
+ * isolated and commented below.
+ */
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useAccount, usePublicClient, useSwitchChain, useWalletClient } from "wagmi";
+import { parseEventLogs, type Abi } from "viem";
+import type {
+  BuyerTeePaymentProofInput,
+  GetQuoteSingleResponse,
+  PeerBuyerTeePaymentCapture,
+  PeerMetadataMessage,
+  PeerMetadataRow,
+} from "@zkp2p/sdk";
+import {
+  ATTESTATION_SERVICE_URL,
+  PEER_CHAIN_ID,
+  PEER_DESTINATION_TOKEN,
+  createPeerClient,
+  ensurePeerReady,
+  getPeerExtension,
+  type PeerFiat,
+  type PeerPlatform,
+} from "@/lib/peerSdk";
+
+export type PeerOnrampStatus =
+  | "idle"
+  | "quoting"
+  | "quote_ready"
+  | "need_extension"
+  | "signalling"
+  | "awaiting_payment"
+  | "verifying"
+  | "success"
+  | "error";
+
+export type PeerOnrampParams = {
+  platform: PeerPlatform;
+  fiat: PeerFiat;
+  amount: string;
+};
+
+function isBuyerTeeParams(value: unknown): value is Record<string, string | number | boolean> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.values(value).every(
+      (v) => typeof v === "string" || typeof v === "number" || typeof v === "boolean",
+    )
+  );
+}
+
+/** Pick the payment row the buyer actually made. Use row.originalIndex, not a UI index. */
+function selectPaymentRow(
+  rows: PeerMetadataRow[],
+  expected: { amount?: string; currency?: string },
+): PeerMetadataRow | null {
+  const visible = rows.filter((r) => !r.hidden && isBuyerTeeParams(r.params));
+  return (
+    visible.find(
+      (r) =>
+        (!expected.amount || r.amount === expected.amount) &&
+        (!expected.currency || r.currency === expected.currency),
+    ) ??
+    visible[0] ??
+    null
+  );
+}
+
+function buildProof(
+  row: PeerMetadataRow,
+  capture: PeerBuyerTeePaymentCapture | null | undefined,
+  platform: PeerPlatform,
+): BuyerTeePaymentProofInput {
+  if (!capture?.encryptedSessionMaterial || !isBuyerTeeParams(row.params)) {
+    throw new Error("Payment row is missing Buyer TEE capture data");
+  }
+  if (platform.includeMetadataIndex && !Number.isInteger(row.originalIndex)) {
+    throw new Error("Payment row is missing its provider metadata index");
+  }
+  return {
+    proofType: "buyerTee",
+    encryptedSessionMaterial: capture.encryptedSessionMaterial,
+    params: {
+      ...row.params,
+      ...(platform.includeMetadataIndex ? { index: row.originalIndex } : {}),
+    },
+    actionPlatform: platform.actionPlatform,
+    actionType: platform.actionType,
+  };
+}
+
+export function usePeerOnramp() {
+  const { address } = useAccount();
+  const { data: walletClient } = useWalletClient({ chainId: PEER_CHAIN_ID });
+  const publicClient = usePublicClient({ chainId: PEER_CHAIN_ID });
+  const { switchChainAsync } = useSwitchChain();
+
+  const [status, setStatus] = useState<PeerOnrampStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [quote, setQuote] = useState<GetQuoteSingleResponse | null>(null);
+
+  // Keep the active metadata subscription so we can tear it down.
+  const unsubscribeRef = useRef<(() => void) | null>(null);
+
+  const reset = useCallback(() => {
+    unsubscribeRef.current?.();
+    unsubscribeRef.current = null;
+    setStatus("idle");
+    setError(null);
+    setQuote(null);
+  }, []);
+
+  const fail = useCallback((message: string) => {
+    unsubscribeRef.current?.();
+    unsubscribeRef.current = null;
+    setError(message);
+    setStatus("error");
+  }, []);
+
+  /** Step 1 — fetch a quote for the chosen platform/currency/amount. */
+  const fetchQuote = useCallback(
+    async ({ platform, fiat, amount }: PeerOnrampParams) => {
+      if (!walletClient || !address) {
+        fail("Connect a wallet first");
+        return null;
+      }
+      setError(null);
+      setStatus("quoting");
+      try {
+        const client = createPeerClient(walletClient);
+        const res = await client.getQuote({
+          paymentPlatforms: [platform.actionPlatform],
+          fiatCurrency: fiat,
+          user: address,
+          recipient: address,
+          destinationChainId: PEER_CHAIN_ID,
+          destinationToken: PEER_DESTINATION_TOKEN,
+          amount,
+          isExactFiat: true,
+        });
+        const best = res.responseObject?.quotes?.[0] ?? null;
+        if (!best) {
+          fail("No offers available for that amount and payment method");
+          return null;
+        }
+        setQuote(best);
+        setStatus("quote_ready");
+        return best;
+      } catch (e) {
+        fail(e instanceof Error ? e.message : "Failed to get a quote");
+        return null;
+      }
+    },
+    [walletClient, address, fail],
+  );
+
+  /** Steps 2-5 — signal the intent, capture payment via the extension, fulfill. */
+  const purchase = useCallback(
+    async ({ platform, fiat }: Omit<PeerOnrampParams, "amount">) => {
+      if (!walletClient || !address || !publicClient || !quote) {
+        fail("Missing wallet, network, or quote");
+        return;
+      }
+
+      try {
+        // Ensure the wallet is on Base for the on-chain steps.
+        if (walletClient.chain?.id !== PEER_CHAIN_ID) {
+          await switchChainAsync({ chainId: PEER_CHAIN_ID });
+        }
+
+        const client = createPeerClient(walletClient);
+
+        // --- Step 2: signal intent (on-chain) ---
+        setStatus("signalling");
+        const intent = quote.intent;
+        const txHash = await client.signalIntent({
+          depositId: String(intent.depositId),
+          amount: quote.signalIntentAmount ?? quote.tokenAmount,
+          toAddress: intent.toAddress as `0x${string}`,
+          processorName: intent.processorName,
+          payeeDetails: intent.payeeDetails,
+          fiatCurrencyCode: intent.fiatCurrencyCode,
+          conversionRate: quote.conversionRate,
+        });
+
+        // NEEDS-REAL-TEST: derive intentHash from the IntentSignaled event. The event
+        // name / arg name should be confirmed against a real receipt; we scan the
+        // orchestrator ABI (then escrow ABI) for an `intentHash` arg.
+        const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+        const intentHash = extractIntentHash(receipt.logs, [
+          client.orchestratorAbi as Abi | undefined,
+          client.escrowAbi as Abi | undefined,
+        ]);
+        if (!intentHash) {
+          fail("Could not read the intent from the transaction — please try again");
+          return;
+        }
+
+        // --- Step 3: ensure the extension is ready ---
+        const readiness = await ensurePeerReady();
+        if (!readiness.ok) {
+          setStatus("need_extension");
+          return;
+        }
+
+        // --- Step 4: register capture handler, then authenticate ---
+        const peer = getPeerExtension();
+        setStatus("awaiting_payment");
+
+        unsubscribeRef.current = peer.onMetadataMessage(async (message: PeerMetadataMessage) => {
+          try {
+            if (message.errorMessage) throw new Error(message.errorMessage);
+            const row = selectPaymentRow(message.metadata, {
+              currency: fiat,
+              amount: quote.fiatAmount,
+            });
+            if (!row) throw new Error("No matching payment was found");
+
+            setStatus("verifying");
+            const proof = buildProof(row, message.buyerTeeCapture, platform);
+
+            // --- Step 5: fulfill (Buyer TEE attestation + on-chain) ---
+            await client.fulfillIntent({
+              intentHash,
+              proof,
+              attestationServiceUrl: ATTESTATION_SERVICE_URL,
+            });
+            setStatus("success");
+          } catch (e) {
+            fail(e instanceof Error ? e.message : "Payment verification failed");
+          } finally {
+            unsubscribeRef.current?.();
+            unsubscribeRef.current = null;
+          }
+        });
+
+        peer.authenticate({
+          actionType: platform.actionType,
+          attestationActionType: platform.actionType,
+          attestationServiceUrl: ATTESTATION_SERVICE_URL,
+          captureMode: "buyerTee",
+          platform: platform.actionPlatform,
+        });
+      } catch (e) {
+        fail(e instanceof Error ? e.message : "Purchase failed");
+      }
+    },
+    [walletClient, address, publicClient, quote, switchChainAsync, fail],
+  );
+
+  const isConnected = useMemo(() => Boolean(address && walletClient), [address, walletClient]);
+
+  return { status, error, quote, isConnected, fetchQuote, purchase, reset };
+}
+
+/** Scan receipt logs for an IntentSignaled-style event carrying an intentHash arg. */
+function extractIntentHash(
+  logs: readonly unknown[],
+  abis: (Abi | undefined)[],
+): `0x${string}` | null {
+  for (const abi of abis) {
+    if (!abi) continue;
+    try {
+      const parsed = parseEventLogs({
+        abi,
+        logs: logs as never,
+        eventName: "IntentSignaled",
+      });
+      for (const ev of parsed) {
+        const args = (ev as { args?: Record<string, unknown> }).args;
+        const hash = args?.intentHash;
+        if (typeof hash === "string" && hash.startsWith("0x")) {
+          return hash as `0x${string}`;
+        }
+      }
+    } catch {
+      // event not in this ABI — try the next
+    }
+  }
+  return null;
+}

--- a/src/lib/mtPelerin.ts
+++ b/src/lib/mtPelerin.ts
@@ -1,5 +1,8 @@
 export const mtPelerinConfig = {
   baseUrl: "https://widget.mtpelerin.com/",
+  // Mt Pelerin's public consumer page — works without a partner key,
+  // but can't pre-fill wallet address or amount.
+  consumerBuyUrl: "https://www.mtpelerin.com/buy-xdai",
   activationKey: process.env.NEXT_PUBLIC_MTPELERIN_ACTIVATION_KEY,
   // xDAI on Gnosis Chain
   network: "xdai_mainnet",
@@ -7,7 +10,16 @@ export const mtPelerinConfig = {
   defaultFiat: "USD",
 };
 
+// The parameterized widget deep-link requires a partner activation key
+// (_ctkn, requested via hello@mtpelerin.com). Without one we fall back
+// to the consumer buy page.
+export const hasMtPelerinKey = Boolean(mtPelerinConfig.activationKey);
+
 export function buildMtPelerinUrl(options?: { inputAmount?: string; recipientAddress?: string }): string {
+  if (!hasMtPelerinKey) {
+    return mtPelerinConfig.consumerBuyUrl;
+  }
+
   const params = new URLSearchParams({
     _ctkn: mtPelerinConfig.activationKey ?? "",
     type: "direct-link",

--- a/src/lib/mtPelerin.ts
+++ b/src/lib/mtPelerin.ts
@@ -1,0 +1,31 @@
+export const mtPelerinConfig = {
+  baseUrl: "https://widget.mtpelerin.com/",
+  activationKey: process.env.NEXT_PUBLIC_MTPELERIN_ACTIVATION_KEY,
+  // xDAI on Gnosis Chain
+  network: "xdai_mainnet",
+  defaultCrypto: "XDAI",
+  defaultFiat: "USD",
+};
+
+export function buildMtPelerinUrl(options?: { inputAmount?: string; recipientAddress?: string }): string {
+  const params = new URLSearchParams({
+    _ctkn: mtPelerinConfig.activationKey ?? "",
+    type: "direct-link",
+    tab: "buy",
+    tabs: "buy",
+    net: mtPelerinConfig.network,
+    nets: mtPelerinConfig.network,
+    bdc: mtPelerinConfig.defaultCrypto,
+    bsc: mtPelerinConfig.defaultFiat,
+  });
+
+  if (options?.inputAmount) {
+    params.set("bsa", options.inputAmount);
+  }
+
+  if (options?.recipientAddress) {
+    params.set("addr", options.recipientAddress);
+  }
+
+  return `${mtPelerinConfig.baseUrl}?${params.toString()}`;
+}

--- a/src/lib/mtPelerin.ts
+++ b/src/lib/mtPelerin.ts
@@ -16,6 +16,10 @@ export function buildMtPelerinUrl(options?: { inputAmount?: string; recipientAdd
     nets: mtPelerinConfig.network,
     bdc: mtPelerinConfig.defaultCrypto,
     bsc: mtPelerinConfig.defaultFiat,
+    // Pre-select card / Google Pay / Apple Pay — the practical rail for
+    // non-European users, for whom bank transfer means a SWIFT wire.
+    // Users can still switch payment method inside the widget.
+    pm: "card",
   });
 
   // Partner activation key (requested via hello@mtpelerin.com). The widget

--- a/src/lib/mtPelerin.ts
+++ b/src/lib/mtPelerin.ts
@@ -1,8 +1,5 @@
 export const mtPelerinConfig = {
   baseUrl: "https://widget.mtpelerin.com/",
-  // Mt Pelerin's public consumer page — works without a partner key,
-  // but can't pre-fill wallet address or amount.
-  consumerBuyUrl: "https://www.mtpelerin.com/buy-xdai",
   activationKey: process.env.NEXT_PUBLIC_MTPELERIN_ACTIVATION_KEY,
   // xDAI on Gnosis Chain
   network: "xdai_mainnet",
@@ -10,18 +7,8 @@ export const mtPelerinConfig = {
   defaultFiat: "USD",
 };
 
-// The parameterized widget deep-link requires a partner activation key
-// (_ctkn, requested via hello@mtpelerin.com). Without one we fall back
-// to the consumer buy page.
-export const hasMtPelerinKey = Boolean(mtPelerinConfig.activationKey);
-
 export function buildMtPelerinUrl(options?: { inputAmount?: string; recipientAddress?: string }): string {
-  if (!hasMtPelerinKey) {
-    return mtPelerinConfig.consumerBuyUrl;
-  }
-
   const params = new URLSearchParams({
-    _ctkn: mtPelerinConfig.activationKey ?? "",
     type: "direct-link",
     tab: "buy",
     tabs: "buy",
@@ -30,6 +17,13 @@ export function buildMtPelerinUrl(options?: { inputAmount?: string; recipientAdd
     bdc: mtPelerinConfig.defaultCrypto,
     bsc: mtPelerinConfig.defaultFiat,
   });
+
+  // Partner activation key (requested via hello@mtpelerin.com). The widget
+  // currently works without one, but only a keyed integration is documented
+  // and gets referral attribution.
+  if (mtPelerinConfig.activationKey) {
+    params.set("_ctkn", mtPelerinConfig.activationKey);
+  }
 
   if (options?.inputAmount) {
     params.set("bsa", options.inputAmount);

--- a/src/lib/mtPelerin.ts
+++ b/src/lib/mtPelerin.ts
@@ -1,5 +1,8 @@
 export const mtPelerinConfig = {
   baseUrl: "https://widget.mtpelerin.com/",
+  // Mt Pelerin's public consumer page — works without a partner key,
+  // but can't pre-fill wallet address or amount.
+  consumerBuyUrl: "https://www.mtpelerin.com/buy-xdai",
   activationKey: process.env.NEXT_PUBLIC_MTPELERIN_ACTIVATION_KEY,
   // xDAI on Gnosis Chain
   network: "xdai_mainnet",
@@ -7,8 +10,18 @@ export const mtPelerinConfig = {
   defaultFiat: "USD",
 };
 
+// The parameterized widget deep-link (amount/address pre-fill) is only
+// used once a partner activation key is configured (requested via
+// hello@mtpelerin.com). Until then we send users to the consumer page.
+export const hasMtPelerinKey = Boolean(mtPelerinConfig.activationKey);
+
 export function buildMtPelerinUrl(options?: { inputAmount?: string; recipientAddress?: string }): string {
+  if (!hasMtPelerinKey) {
+    return mtPelerinConfig.consumerBuyUrl;
+  }
+
   const params = new URLSearchParams({
+    _ctkn: mtPelerinConfig.activationKey ?? "",
     type: "direct-link",
     tab: "buy",
     tabs: "buy",
@@ -16,18 +29,7 @@ export function buildMtPelerinUrl(options?: { inputAmount?: string; recipientAdd
     nets: mtPelerinConfig.network,
     bdc: mtPelerinConfig.defaultCrypto,
     bsc: mtPelerinConfig.defaultFiat,
-    // Pre-select card / Google Pay / Apple Pay — the practical rail for
-    // non-European users, for whom bank transfer means a SWIFT wire.
-    // Users can still switch payment method inside the widget.
-    pm: "card",
   });
-
-  // Partner activation key (requested via hello@mtpelerin.com). The widget
-  // currently works without one, but only a keyed integration is documented
-  // and gets referral attribution.
-  if (mtPelerinConfig.activationKey) {
-    params.set("_ctkn", mtPelerinConfig.activationKey);
-  }
 
   if (options?.inputAmount) {
     params.set("bsa", options.inputAmount);

--- a/src/lib/peer.ts
+++ b/src/lib/peer.ts
@@ -1,26 +1,13 @@
 export const peerConfig = {
-  baseUrl: "https://peer.xyz/swap",
-  referrer: "Bread Solidarity Fund",
-  referrerLogo: "https://fund.bread.coop/logo.svg",
-  // xDAI on Gnosis Chain (chainId: 100, native token)
-  toToken: "100:0x0000000000000000000000000000000000000000",
+  // Peer (formerly ZKP2P) deprecated their deeplink/redirect onramp as of
+  // extension 0.6.0 — URL params like toToken, inputAmount, recipientAddress
+  // and callbackUrl are ignored, and Gnosis Chain is no longer a supported
+  // destination (buyers receive USDC on Base/Arbitrum/etc.). We link to the
+  // marketplace and guide the user from our side; bridging back to Gnosis
+  // is covered by the Bridge tab.
+  marketplaceUrl: "https://peer.xyz/",
 };
 
-export function buildPeerUrl(options?: { inputAmount?: string; recipientAddress?: string }): string {
-  const params = new URLSearchParams({
-    referrer: peerConfig.referrer,
-    referrerLogo: peerConfig.referrerLogo,
-    toToken: peerConfig.toToken,
-    callbackUrl: `${window.location.origin}/?peer=success`,
-  });
-
-  if (options?.inputAmount) {
-    params.set("inputAmount", options.inputAmount);
-  }
-
-  if (options?.recipientAddress) {
-    params.set("recipientAddress", options.recipientAddress);
-  }
-
-  return `${peerConfig.baseUrl}?${params.toString()}`;
+export function buildPeerUrl(): string {
+  return peerConfig.marketplaceUrl;
 }

--- a/src/lib/peer.ts
+++ b/src/lib/peer.ts
@@ -3,9 +3,9 @@ export const peerConfig = {
   // extension 0.6.0 — URL params like toToken, inputAmount, recipientAddress
   // and callbackUrl are ignored, and Gnosis Chain is no longer a supported
   // destination (buyers receive USDC on Base/Arbitrum/etc.). We link to the
-  // marketplace and guide the user from our side; bridging back to Gnosis
-  // is covered by the Bridge tab.
-  marketplaceUrl: "https://peer.xyz/",
+  // trade page (their "TRADE" nav target) and guide the user from our side;
+  // bridging back to Gnosis is covered by the Bridge tab.
+  marketplaceUrl: "https://www.peer.xyz/liquidity",
 };
 
 export function buildPeerUrl(): string {

--- a/src/lib/peerSdk.ts
+++ b/src/lib/peerSdk.ts
@@ -61,12 +61,14 @@ export type PeerPlatform = {
   actionPlatform: string;
   actionType: string;
   includeMetadataIndex: boolean;
+  /** Fiat currencies this platform can pay in. Venmo is USD-only; Wise/Revolut are multi-currency. */
+  currencies: PeerFiat[];
 };
 
 export const PEER_PLATFORMS: PeerPlatform[] = [
-  { key: "wise", label: "Wise", actionPlatform: "wise", actionType: "transfer_wise", includeMetadataIndex: false },
-  { key: "revolut", label: "Revolut", actionPlatform: "revolut", actionType: "transfer_revolut", includeMetadataIndex: true },
-  { key: "venmo", label: "Venmo", actionPlatform: "venmo", actionType: "transfer_venmo", includeMetadataIndex: true },
+  { key: "wise", label: "Wise", actionPlatform: "wise", actionType: "transfer_wise", includeMetadataIndex: false, currencies: ["USD", "EUR", "GBP"] },
+  { key: "revolut", label: "Revolut", actionPlatform: "revolut", actionType: "transfer_revolut", includeMetadataIndex: true, currencies: ["USD", "EUR", "GBP"] },
+  { key: "venmo", label: "Venmo", actionPlatform: "venmo", actionType: "transfer_venmo", includeMetadataIndex: true, currencies: ["USD"] },
 ];
 
 export function getPeerPlatform(key: string): PeerPlatform | undefined {

--- a/src/lib/peerSdk.ts
+++ b/src/lib/peerSdk.ts
@@ -1,0 +1,137 @@
+"use client";
+
+/**
+ * Thin wrapper around @zkp2p/sdk for the in-app Peer onramp (Buyer TEE flow).
+ *
+ * Peer deprecated the old redirect/deeplink onramp; the supported path is this
+ * headless SDK flow where our app owns the UI and the PeerAuth browser extension
+ * (>= 0.6.3) acts as a payment-capture bridge. No API key is required for the
+ * buyer flow — `apiKey`/`authorizationToken` on Zkp2pClient are for seller/curator
+ * operations only.
+ *
+ * IMPORTANT: this module talks to a live protocol on Base mainnet and could not be
+ * runtime-tested in the dev sandbox. The lifecycle matches Peer's agent guide and
+ * the SDK's published types, but the on-chain + extension path must be verified
+ * with a real wallet + the extension on the deploy preview. Spots that most need
+ * that confirmation are marked NEEDS-REAL-TEST.
+ */
+
+import {
+  Zkp2pClient,
+  createPeerExtensionSdk,
+  SUPPORTED_CHAIN_IDS,
+  Currency,
+  type CurrencyType,
+  type PeerExtensionSdk,
+  type PeerExtensionState,
+} from "@zkp2p/sdk";
+import type { WalletClient } from "viem";
+
+/** Base mainnet — the only chain Peer delivers onramp funds to. */
+export const PEER_CHAIN_ID: number = SUPPORTED_CHAIN_IDS.BASE_MAINNET; // 8453
+
+/** Native USDC on Base — the token buyers receive. */
+export const PEER_DESTINATION_TOKEN = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+/** Peer's Buyer TEE attestation service. */
+export const ATTESTATION_SERVICE_URL = "https://attestation-service.zkp2p.xyz";
+
+/** Minimum extension version that supports the headless Buyer TEE capture. */
+export const MIN_PEER_EXTENSION_VERSION = "0.6.3";
+
+export type PeerFiat = "USD" | "EUR" | "GBP";
+
+export const PEER_FIATS: { code: PeerFiat; currency: CurrencyType }[] = [
+  { code: "USD", currency: Currency.USD },
+  { code: "EUR", currency: Currency.EUR },
+  { code: "GBP", currency: Currency.GBP },
+];
+
+/**
+ * Per-platform Buyer TEE routing config.
+ *
+ * `includeMetadataIndex` rule is from Peer's agent guide: include the provider
+ * metadata index only for Venmo, Cash App, Revolut, Zelle. `actionType` values
+ * follow the documented `transfer_<platform>` convention (Venmo confirmed in the
+ * guide as `transfer_venmo`). NEEDS-REAL-TEST for the non-Venmo action types.
+ */
+export type PeerPlatform = {
+  key: string;
+  label: string;
+  actionPlatform: string;
+  actionType: string;
+  includeMetadataIndex: boolean;
+};
+
+export const PEER_PLATFORMS: PeerPlatform[] = [
+  { key: "wise", label: "Wise", actionPlatform: "wise", actionType: "transfer_wise", includeMetadataIndex: false },
+  { key: "revolut", label: "Revolut", actionPlatform: "revolut", actionType: "transfer_revolut", includeMetadataIndex: true },
+  { key: "venmo", label: "Venmo", actionPlatform: "venmo", actionType: "transfer_venmo", includeMetadataIndex: true },
+];
+
+export function getPeerPlatform(key: string): PeerPlatform | undefined {
+  return PEER_PLATFORMS.find((p) => p.key === key);
+}
+
+export function getPeerFiat(code: PeerFiat): CurrencyType {
+  return PEER_FIATS.find((f) => f.code === code)?.currency ?? Currency.USD;
+}
+
+/** Construct an app-owned Zkp2pClient from a viem WalletClient (must be on Base). */
+export function createPeerClient(walletClient: WalletClient): Zkp2pClient {
+  return new Zkp2pClient({
+    walletClient,
+    chainId: PEER_CHAIN_ID,
+  });
+}
+
+/** Lazily-created singleton extension bridge (browser only). */
+let _peerExtension: PeerExtensionSdk | null = null;
+
+export function getPeerExtension(): PeerExtensionSdk {
+  if (typeof window === "undefined") {
+    throw new Error("Peer extension is only available in the browser");
+  }
+  if (!_peerExtension) {
+    _peerExtension = createPeerExtensionSdk({ window });
+  }
+  return _peerExtension;
+}
+
+export function isPeerExtension063OrNewer(version: string): boolean {
+  const [major = 0, minor = 0, patch = 0] = version.split(".").map(Number);
+  if (major !== 0) return major > 0;
+  if (minor !== 6) return minor > 6;
+  return patch >= 3;
+}
+
+export type PeerReadiness =
+  | { ok: true }
+  | { ok: false; reason: "needs_install" | "needs_connection" | "outdated"; version?: string };
+
+/**
+ * Ensure the extension is installed, connected, and new enough. Opens the install
+ * page or requests connection as needed. Returns a structured readiness result so
+ * the UI can render the right prompt rather than throwing.
+ */
+export async function ensurePeerReady(): Promise<PeerReadiness> {
+  const peer = getPeerExtension();
+  const state: PeerExtensionState = await peer.getState();
+
+  if (state === "needs_install") {
+    peer.openInstallPage();
+    return { ok: false, reason: "needs_install" };
+  }
+
+  if (state === "needs_connection") {
+    const approved = await peer.requestConnection();
+    if (!approved) return { ok: false, reason: "needs_connection" };
+  }
+
+  const version = await peer.getVersion();
+  if (!isPeerExtension063OrNewer(version)) {
+    return { ok: false, reason: "outdated", version };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
Stacked on #434 (base = `buy-tab-providers`). The "improved version" of the Peer buy flow: users pick platform/currency/amount and pay **inside the app** instead of being sent to peer.xyz — matching the mockup.

## How it works
Peer deprecated the redirect onramp; the supported path is the headless SDK where our app owns the UI and the PeerAuth extension (>=0.6.3) is a payment-capture bridge. **No API key needed** for the buyer flow.

- `src/lib/peerSdk.ts` — `Zkp2pClient` factory (Base mainnet 8453), extension wrapper (`ensurePeerReady`), platform config (Wise/Revolut/Venmo + `includeMetadataIndex` rules), attestation URL.
- `usePeerOnramp.ts` — state machine: `getQuote → signalIntent` (on-chain) `→` ensure extension `→ authenticate` (opens payment tab, captures) `→ fulfillIntent` (Buyer TEE + on-chain) `→` success. Switches wallet to Base; hands off to the Bridge tab on success.
- `PeerBuy.tsx` — stepped SDK UI (mockup) with the link-out kept as fallback for mobile / disconnected wallets.
- Bumps `viem` to `^2.37.3` (SDK peer range), adds `@zkp2p/sdk ^0.7.2`.

## ⚠️ Needs a real test before merge
This could **not** be runtime-tested in the dev sandbox (no wallet/extension, dev server won't boot there). It compiles clean (`tsc`) and lints clean, and is wired to the SDK's published types + Peer's agent guide — but the on-chain + extension path must be exercised on the deploy preview with a real wallet + the PeerAuth extension. Two spots most likely to need adjustment, both isolated and commented `NEEDS-REAL-TEST`:
1. Extracting `intentHash` from the `signalIntent` receipt (event/arg name).
2. Payment-row matching in the capture callback.

Also open: the **gas model** — `signalIntent`/`fulfillIntent` are txs on Base, so the user needs ETH on Base unless Peer sponsors it. Confirm during the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)