### PR TITLE
Update governance page link-preview title to "Bread Coop Governance"

### DIFF
--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -2,7 +2,7 @@ import { generateMetadata } from "@/lib/site-metadata";
 import { GovernancePage } from "./GovernancePage";
 import { Metadata } from "next";
 
-export const metadata = generateMetadata({title: "Bread Voting"});
+export const metadata = generateMetadata({title: "Bread Coop Governance"});
 
 export default function Governance() {
   return <GovernancePage />;


### PR DESCRIPTION
Small copy fix: the /governance page's title (used for the browser tab and the OpenGraph/Twitter link-preview title when the page is shared) was "Bread Voting". Updated to **"Bread Coop Governance"**.

Single-line change in `src/app/governance/page.tsx`, via the shared `generateMetadata()` helper in `src/lib/site-metadata.ts` (unchanged).

Verified with `tsc --noEmit` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)